### PR TITLE
Port to Anki 2.1.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from . import crowd_anki_importer

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,4 @@
-from . import crowd_anki_importer
+try:
+    from . import crowd_anki_importer
+except ValueError:
+    pass

--- a/crowd_anki/anki_exporter.py
+++ b/crowd_anki/anki_exporter.py
@@ -4,10 +4,10 @@ import shutil
 
 import anki.utils
 
-from thirdparty.pathlib import Path
+from .thirdparty.pathlib import Path
 
-from crowd_anki.utils.constants import DECK_FILE_EXTENSION, MEDIA_SUBDIRECTORY_NAME
-from crowd_anki.representation.deck import Deck
+from .utils.constants import DECK_FILE_EXTENSION, MEDIA_SUBDIRECTORY_NAME
+from .representation.deck import Deck
 
 
 class AnkiJsonExporter(object):

--- a/crowd_anki/anki_exporter.py
+++ b/crowd_anki/anki_exporter.py
@@ -42,8 +42,7 @@ class AnkiJsonExporter(object):
                                        default=Deck.default_json,
                                        sort_keys=True,
                                        indent=4,
-                                       ensure_ascii=False,
-                                       encoding="utf8"))
+                                       ensure_ascii=False))
 
         self._save_changes()
 

--- a/crowd_anki/anki_exporter.py
+++ b/crowd_anki/anki_exporter.py
@@ -4,7 +4,7 @@ import shutil
 
 import anki.utils
 
-from .thirdparty.pathlib import Path
+from .utils.pathlib_wrapper import Path
 
 from .utils.constants import DECK_FILE_EXTENSION, MEDIA_SUBDIRECTORY_NAME
 from .representation.deck import Deck

--- a/crowd_anki/anki_exporter_wrapper.py
+++ b/crowd_anki/anki_exporter_wrapper.py
@@ -1,4 +1,4 @@
-from .thirdparty.pathlib import Path
+from .utils.pathlib_wrapper import Path
 
 import anki.exporting
 import aqt.utils

--- a/crowd_anki/anki_exporter_wrapper.py
+++ b/crowd_anki/anki_exporter_wrapper.py
@@ -1,4 +1,3 @@
-#from . import crowd_anki # Unnecessary?
 from .thirdparty.pathlib import Path
 
 import anki.exporting
@@ -32,7 +31,7 @@ class AnkiJsonExporterWrapper:
     def exportInto(self, directory_path):
         if self.did is None:
             aqt.utils.showWarning("CrowdAnki works only with specific decks.", title="Export failed")
-            return 
+            return
 
         deck_name = self.collection.decks.get(self.did, default=False)["name"]
         self.anki_json_exporter.export_deck_to_directory(deck_name, Path(directory_path).parent, self.includeMedia)

--- a/crowd_anki/anki_exporter_wrapper.py
+++ b/crowd_anki/anki_exporter_wrapper.py
@@ -1,12 +1,12 @@
-import crowd_anki
-from thirdparty.pathlib import Path
+#from . import crowd_anki # Unnessecary?
+from .thirdparty.pathlib import Path
 
 import anki.exporting
 import aqt.utils
 
-import crowd_anki.utils.constants
-from crowd_anki.anki_exporter import AnkiJsonExporter
-from crowd_anki.anki_overrides import exporting
+from .utils import constants
+from .anki_exporter import AnkiJsonExporter
+from .anki_overrides import exporting
 
 
 class AnkiJsonExporterWrapper:
@@ -15,7 +15,7 @@ class AnkiJsonExporterWrapper:
     """
 
     key = "CrowdAnki Json representation"
-    ext = crowd_anki.utils.constants.ANKI_EXPORT_EXTENSION
+    ext = constants.ANKI_EXPORT_EXTENSION
     hideTags = True
     includeTags = True
     directory_export = True

--- a/crowd_anki/anki_exporter_wrapper.py
+++ b/crowd_anki/anki_exporter_wrapper.py
@@ -1,4 +1,4 @@
-#from . import crowd_anki # Unnessecary?
+#from . import crowd_anki # Unnecessary?
 from .thirdparty.pathlib import Path
 
 import anki.exporting

--- a/crowd_anki/anki_importer.py
+++ b/crowd_anki/anki_importer.py
@@ -1,13 +1,17 @@
 import json
 import shutil
 import os
-from thirdparty.pathlib import Path
+from .thirdparty.pathlib import Path
+try:
+    unicode('')
+except NameError:
+    unicode = str
 
 import aqt
 import aqt.utils
 
-from crowd_anki.utils.constants import DECK_FILE_EXTENSION, MEDIA_SUBDIRECTORY_NAME
-from crowd_anki.representation.deck import Deck
+from .utils.constants import DECK_FILE_EXTENSION, MEDIA_SUBDIRECTORY_NAME
+from .representation.deck import Deck
 
 
 class AnkiJsonImporter(object):

--- a/crowd_anki/anki_importer.py
+++ b/crowd_anki/anki_importer.py
@@ -1,7 +1,7 @@
 import json
 import shutil
 import os
-from .thirdparty.pathlib import Path
+from .utils.pathlib_wrapper import Path
 try:
     unicode('')
 except NameError:

--- a/crowd_anki/anki_overrides/exporting.py
+++ b/crowd_anki/anki_overrides/exporting.py
@@ -9,7 +9,7 @@ import anki.exporting
 from anki.exporting import AnkiExporter
 from aqt.exporting import ExportDialog
 
-import crowd_anki.utils.constants
+from ..utils import constants
 
 
 def get_files_for_models(self, model_ids, media_dir):
@@ -40,7 +40,7 @@ def exporter_changed(self, exporter_id):
 
 
 def get_save_file(parent, title, dir_description, key, ext, fname=None):
-    if ext == crowd_anki.utils.constants.ANKI_EXPORT_EXTENSION:
+    if ext == constants.ANKI_EXPORT_EXTENSION:
         directory = str(QFileDialog.getExistingDirectory(caption="Select Export Directory",
                                                          directory=fname))
         if directory:

--- a/crowd_anki/anki_overrides/uuid_operations.py
+++ b/crowd_anki/anki_overrides/uuid_operations.py
@@ -1,7 +1,7 @@
 from anki.notes import Note as AnkiNote
 from anki.decks import DeckManager
 from anki.models import ModelManager
-from crowd_anki.utils.constants import UUID_FIELD_NAME
+from ..utils.constants import UUID_FIELD_NAME
 
 
 # AnkiNote

--- a/crowd_anki/github/github_importer.py
+++ b/crowd_anki/github/github_importer.py
@@ -1,11 +1,16 @@
-import urllib2
+try:
+    from urllib.request import urlopen
+    from urllib.error import HTTPError, URLError
+except ImportError:
+    from urllib2 import urlopen, HTTPError, URLError
+
 import zipfile
 import tempfile
-import StringIO
+from io import BytesIO
 
-from crowd_anki.utils import utils
-from crowd_anki.thirdparty.pathlib import Path
-from crowd_anki.anki_importer import AnkiJsonImporter
+from ..utils import utils
+from ..thirdparty.pathlib import Path
+from ..anki_importer import AnkiJsonImporter
 
 import aqt.utils
 
@@ -36,8 +41,8 @@ class GithubImporter(object):
 
     def download_and_import(self, repo):
         try:
-            response = urllib2.urlopen(GITHUB_LINK.format(repo))
-            response_sio = StringIO.StringIO(response.read())
+            response = urlopen(GITHUB_LINK.format(repo))
+            response_sio = BytesIO(response.read())
             with zipfile.ZipFile(response_sio) as repo_zip:
                 repo_zip.extractall(tempfile.tempdir)
 
@@ -50,6 +55,6 @@ class GithubImporter(object):
 
             AnkiJsonImporter.import_deck(self.collection, deck_directory)
 
-        except (urllib2.URLError, urllib2.HTTPError, OSError) as error:
+        except (URLError, HTTPError, OSError) as error:
             aqt.utils.showWarning("Error while trying to get deck from Github: {}".format(error))
             raise

--- a/crowd_anki/github/github_importer.py
+++ b/crowd_anki/github/github_importer.py
@@ -9,7 +9,7 @@ import tempfile
 from io import BytesIO
 
 from ..utils import utils
-from ..thirdparty.pathlib import Path
+from ..utils.pathlib_wrapper import Path
 from ..anki_importer import AnkiJsonImporter
 
 import aqt.utils

--- a/crowd_anki/main.py
+++ b/crowd_anki/main.py
@@ -1,7 +1,4 @@
-try:
-    from pathlib import Path
-except ImportError:
-    from .thirdparty.pathlib import Path
+from .utils.pathlib_wrapper import Path
 
 from . import anki_exporter_wrapper  # Do not remove. To hook exporters list extension
 from .anki_importer import AnkiJsonImporter

--- a/crowd_anki/main.py
+++ b/crowd_anki/main.py
@@ -1,8 +1,11 @@
-from thirdparty.pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from .thirdparty.pathlib import Path
 
-from crowd_anki import anki_exporter_wrapper  # Do not remove. To hook exporters list extension
-from crowd_anki.anki_importer import AnkiJsonImporter
-from crowd_anki.github.github_importer import GithubImporter
+from . import anki_exporter_wrapper  # Do not remove. To hook exporters list extension
+from .anki_importer import AnkiJsonImporter
+from .github.github_importer import GithubImporter
 
 import aqt.utils
 from aqt import mw, QAction, QFileDialog

--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -1,7 +1,7 @@
 from collections import namedtuple, defaultdict
 
-from crowd_anki.utils import utils
-from crowd_anki.utils.constants import UUID_FIELD_NAME
+from ..utils import utils
+from ..utils.constants import UUID_FIELD_NAME
 
 from anki.exporting import AnkiExporter
 from .deck_config import DeckConfig

--- a/crowd_anki/representation/json_serializable.py
+++ b/crowd_anki/representation/json_serializable.py
@@ -1,7 +1,7 @@
 from uuid import uuid1
 
-from crowd_anki.utils import utils
-from crowd_anki.utils.constants import UUID_FIELD_NAME
+from ..utils import utils
+from ..utils.constants import UUID_FIELD_NAME
 
 
 class JsonSerializable(object):

--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -8,7 +8,7 @@ except ImportError:
     # need this to decouple it from pyqt. To simplify running of the tests with Travis
     print("Failed to import ChangeModelDialog")
 
-from crowd_anki.utils.constants import UUID_FIELD_NAME
+from ..utils.constants import UUID_FIELD_NAME
 from .json_serializable import JsonSerializableAnkiObject
 from .note_model import NoteModel
 

--- a/crowd_anki/representation/note_model.py
+++ b/crowd_anki/representation/note_model.py
@@ -6,7 +6,7 @@ except ImportError:
     # need this to decouple it from pyqt. To simplify running of the tests with Travis
     print("Failed to import ChangeModelDialog")
 
-from crowd_anki.utils import utils
+from ..utils import utils
 from .json_serializable import JsonSerializableAnkiDict
 
 

--- a/crowd_anki/test/test_utils.py
+++ b/crowd_anki/test/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from crowd_anki.thirdparty.pathlib import Path
+from crowd_anki.utils.pathlib_wrapper import Path
 from crowd_anki.utils import utils
 
 

--- a/crowd_anki/utils/pathlib_wrapper.py
+++ b/crowd_anki/utils/pathlib_wrapper.py
@@ -1,0 +1,4 @@
+try:
+    from pathlib import Path
+except ImportError:
+    from ..thirdparty.pathlib import Path

--- a/crowd_anki/utils/utils.py
+++ b/crowd_anki/utils/utils.py
@@ -3,7 +3,10 @@ import shutil
 import os
 from pprint import pprint
 from sqlite3 import OperationalError
-
+try:
+    unicode('')
+except NameError:
+    unicode = str
 
 def merge_dicts(*dict_args):
     """
@@ -53,6 +56,6 @@ def fs_remove(path):
         return
 
     if path.is_dir():
-        shutil.rmtree(unicode(str(path)))
+        shutil.rmtree(str(path))
     else:
-        os.remove(unicode(str(path)))
+        os.remove(str(path))

--- a/crowd_anki/utils/utils.py
+++ b/crowd_anki/utils/utils.py
@@ -56,6 +56,6 @@ def fs_remove(path):
         return
 
     if path.is_dir():
-        shutil.rmtree(str(path))
+        shutil.rmtree(unicode(str(path)))
     else:
-        os.remove(str(path))
+        os.remove(unicode(str(path)))

--- a/crowd_anki_importer.py
+++ b/crowd_anki_importer.py
@@ -1,1 +1,4 @@
-import crowd_anki.main
+try:
+    from crowd_anki import main
+except ModuleNotFoundError:
+    from .crowd_anki import main


### PR DESCRIPTION
Adds compatibility for Anki 2.1.X and maintains compatibility with Anki 2.0.X. #1 

Thank you for your feedback @Stvad .
I tried to work it in as best I could.

- Instead of using 2to3, I rewrote the code base by hand. I changed the imports from absolute to relative, because Python 3 is no longer compatible to absolute paths. 
- I took AnkiHub Support back in, thought it would not be compatible to Python 3, but it's in a try-catch block anyway.

I hope you're comfortable with the changes, if not, I'll be happy to make more adjustments.