### PR TITLE
Fixed a crash that occurred when exporting a deck with nested 'filtered decks'

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,12 @@ The current workflow could be described as following:
 ## Export
 To perform the export go to menu File>Export
 
-Select the deck (**note**: export of "All decks" is not supported, you need to select a specific deck) and the export format "CrowdAnki JSON representation".
+Select the deck and the export format "CrowdAnki JSON representation".
 After pressing the Export button - select directory where the result should be stored.
+
+### Limitations:
+* Export of "All decks" is not supported, you need to select a specific deck
+* Export of a filtered deck is not supported, export the main deck instead and filter it again after importing. You don't have to delete existing filtered decks, as all cards are still part of the main deck. When exporting nested decks, filtered sub-decks are just ignored.
 
 ## Import
 To perform the import go to menu File>"CrowdAnki: Import from disk" and select the directory where the deck is stored.

--- a/crowd_anki/anki_exporter_wrapper.py
+++ b/crowd_anki/anki_exporter_wrapper.py
@@ -32,9 +32,15 @@ class AnkiJsonExporterWrapper:
     def exportInto(self, directory_path):
         if self.did is None:
             aqt.utils.showWarning("CrowdAnki works only with specific decks.", title="Export failed")
-            return 
+            return
 
-        deck_name = self.collection.decks.get(self.did, default=False)["name"]
+        selected_deck = self.collection.decks.get(self.did, default=False)
+
+        if 'conf' not in selected_deck:
+            aqt.utils.showWarning("CrowdAnki does not support exporting filtered decks.", title="Export failed")
+            return
+
+        deck_name = selected_deck["name"]
         self.anki_json_exporter.export_deck_to_directory(deck_name, Path(directory_path).parent, self.includeMedia)
         # .parent because we receive name with random numbers at the end (hacking around internals of Anki) :(
 

--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -60,6 +60,10 @@ class Deck(JsonSerializableAnkiDict):
     def from_collection(cls, collection, name, deck_metadata=None, is_child=False):
         anki_dict = collection.decks.byName(name)
 
+        # Todo Maybe add support for exporting filtered decks?
+        if 'conf' not in anki_dict:
+            raise ValueError("Can't process a filtered deck.")
+
         deck = Deck(anki_dict, is_child)
 
         deck.collection = collection
@@ -75,8 +79,12 @@ class Deck(JsonSerializableAnkiDict):
                            if Deck.DECK_NAME_DELIMITER
                            not in child_name[len(name) + len(Deck.DECK_NAME_DELIMITER):]]
 
+        # Remove filtered decks from list
+        direct_children_filtered = [child_name for child_name in direct_children
+                                    if 'conf' in collection.decks.byName(child_name)]
+
         deck.children = [cls.from_collection(collection, child_name, deck.metadata, True)
-                         for child_name in direct_children]
+                         for child_name in direct_children_filtered]
 
         return deck
 


### PR DESCRIPTION
I tried to export a deck that has some filtered sub decks and apparently filtered decks have no 'conf' attribute. As cards in filtered decks are still present in the original deck (checked the card count), the filtered decks can safely be ignored when exporting the original.

I excluded the filtered decks when the child decks are processed, and the export of the parent deck works as expected. Importing works without a problem. I also added a warning message when the user tries to export a filtered deck directly, as this produces the same key error.

**Error message**
```
Traceback (most recent call last):
  File "aqt\exporting.py", line 116, in accept
  File "C:\Users\***\AppData\Roaming\Anki2\addons\crowd_anki\anki_exporter_wrapper.py", line 38, in exportInto
    self.anki_json_exporter.export_deck_to_directory(deck_name, Path(directory_path).parent, self.includeMedia)
  File "C:\Users\***\AppData\Roaming\Anki2\addons\crowd_anki\anki_exporter.py", line 36, in export_deck_to_directory
    deck = Deck.from_collection(self.collection, deck_name)
  File "C:\Users\***\AppData\Roaming\Anki2\addons\crowd_anki\representation\deck.py", line 79, in from_collection
    for child_name in direct_children]
  File "C:\Users\***\AppData\Roaming\Anki2\addons\crowd_anki\representation\deck.py", line 70, in from_collection
    deck._load_metadata()
  File "C:\Users\***\AppData\Roaming\Anki2\addons\crowd_anki\representation\deck.py", line 94, in _load_metadata
    self._load_deck_config()
  File "C:\Users\***\AppData\Roaming\Anki2\addons\crowd_anki\representation\deck.py", line 98, in _load_deck_config
    new_config = DeckConfig.from_collection(self.collection, self.anki_dict["conf"])
KeyError: 'conf'
```

**Example: Properties of a filtered deck**
```
{u'browserCollapsed': True, u'terms': [[u'deck:"My deck"  is:due prop:due<=-4', 1, 1]], u'name': u'My deck::Over Due', u'separate': True, u'usn': 0, u'collapsed': False, u'resched': True, u'newToday': [1341, 0], u'mid': 1342700818760L, u'timeToday': [1341, 0], u'dyn': 1, u'delays': None, u'crowdanki_uuid': u'2d617e3b-36b3-11e8-8809-1c1b0d602fce', u'return': True, u'revToday': [1341, 0], u'lrnToday': [1341, 0], u'id': 1484015247363L, u'mod': 1512868704, u'desc': u''}
```