### PR TITLE
New Note Filter for "newlyAdded"

### DIFF
--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -16,7 +16,8 @@ class Note(JsonSerializableAnkiObject):
                          "_model",  # Card model. Would be handled by deck.
                          "mid",  # -> uuid
                          "scm",  # todo: clarify
-                         "config"
+                         "config",
+                         "newlyAdded"
                          }
 
     def __init__(self, anki_note=None, config: ConfigSettings = None):


### PR DESCRIPTION
Was comparing some exports and saw there's a new field on Notes called "newlyAdded". Having a look at the Anki source it seems it's just used for notification purposes, just now at least. Don't think this is wanted, or needed, in a CrowdAnkiExport though.

Added it into the Note Filter. May be good to get some type of automated test to check this in the future :thinking: 