### PR TITLE
Hotfix for Import on Latest Anki

### DIFF
--- a/crowd_anki/anki/overrides/uuid_operations.py
+++ b/crowd_anki/anki/overrides/uuid_operations.py
@@ -34,7 +34,7 @@ def get_deck_by_uuid(self, uuid):
 
 # Deck configuration
 def get_deck_configuration_by_uuid(self, uuid):
-    return get_from_dict_by_uuid(self, "dconf", uuid)
+    return get_from_dict_by_uuid(self, "decks", uuid)
 
 
 # Note model

--- a/crowd_anki/representation/json_serializable.py
+++ b/crowd_anki/representation/json_serializable.py
@@ -6,8 +6,8 @@ from ..utils.constants import UUID_FIELD_NAME
 
 class JsonSerializable:
     readable_names = {}
-    export_filter_set = {"mod",  # Modification time
-                         "usn",  # Todo clarify
+    export_filter_set = {  # "mod",  # Modification time
+                           # "usn",  # Todo clarify
                          "id"}
     import_filter_set = {"__type__"}
 


### PR DESCRIPTION
Working Version: Fix UUID get, and remove "mod" and "usn" from export filter. Fixes #84 

Ran into this issue while working on #72, so I decided to take a crack at it. This little fix makes things work again, but I believe it is not a great solution :slightly_frowning_face: 

The 'DeckManager' object has no attribute 'dconf' issue seemed to be caused by some restructuring of Decks/Deck Managers in Anki, so I've got it to point to the right place ("decks" instead of "dconf"). After this was fixed another issue cropped up, complaining there were missing properties. It seems that the latest Anki requires "mod" and "usn" on import, for some reason :thinking: I removed them from the export_filter, re-exported my test deck, and imported it successfully :+1:

Though I do not like the idea of mod and usn being in the json export files, further cluttering things up. Would be better for CrowdAnki to insert the mod and usn values. According to [this documentation](https://github.com/ankidroid/Anki-Android/wiki/Database-Structure) the mod is just the modification time (doable) but the usn may be more tricky :thinking: "-1" is probably fine, but may cause some sync issues?

Anyways I am unsure what the perfect fix for this is, or whether it should be fixed on Anki's end, so here's this working PR for now. Pull it, reject it, brainstorms other ideas and I can give them a try if I have time :+1: 