### PR TITLE
Update note, deck and model management for Anki 2.1.28+

### DIFF
--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -171,7 +171,9 @@ class Deck(JsonSerializableAnkiDict):
         self.anki_dict = deck_dict
         self.anki_dict["name"] = full_name
         self.anki_dict["conf"] = self.metadata.deck_configs[self.deck_config_uuid].anki_dict["id"]
-        collection.decks.save()
+        collection.decks.save(deck_dict)
+        # TODO: remove when compatibility with Anki < 2.1.28 is no longer needed
+        # DeckManager.flush() is now a no-op
         collection.decks.flush()
 
         return full_name

--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -172,9 +172,6 @@ class Deck(JsonSerializableAnkiDict):
         self.anki_dict["name"] = full_name
         self.anki_dict["conf"] = self.metadata.deck_configs[self.deck_config_uuid].anki_dict["id"]
         collection.decks.save(deck_dict)
-        # TODO: remove when compatibility with Anki < 2.1.28 is no longer needed
-        # DeckManager.flush() is now a no-op
-        collection.decks.flush()
 
         return full_name
 

--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -104,11 +104,18 @@ class Note(JsonSerializableAnkiObject):
         # Todo uuid match on existing notes
 
         note_model = deck.metadata.models[self.note_model_uuid]
-        # You may ask WTF? Well, it seems anki has 2 ways to identify deck where to place card:
-        # 1) Looking for existing cards of this note
-        # 2) Looking at model->did and to add new cards to correct deck we need to modify the did each time
-        # ;(
-        note_model.anki_dict["did"] = deck.anki_dict["id"]
+
+        # Anki 2.1.28 made addition of notes slightly saner
+        # TODO: Refactor once compatibility with 2.1.26 is not needed.
+        # (2.1.27 doesn't seem to have existed.)
+        saner_note_addition = int(anki.version.split(".")[-1]) > 26
+
+        if not saner_note_addition:
+            # You may ask WTF? Well, it seems anki has 2 ways to identify deck where to place card:
+            # 1) Looking for existing cards of this note
+            # 2) Looking at model->did and to add new cards to correct deck we need to modify the did each time
+            # ;(
+            note_model.anki_dict["did"] = deck.anki_dict["id"]
 
         self.anki_object = UuidFetcher(collection).get_note(self.get_uuid())
         new_note = self.anki_object is None
@@ -122,12 +129,17 @@ class Note(JsonSerializableAnkiObject):
         self.anki_object.__dict__.update(self.anki_object_dict)
         self.anki_object.mid = note_model.anki_dict["id"]
         self.anki_object.mod = anki.utils.intTime()
-        self.anki_object.flush()
 
         if new_note:
-            collection.addNote(self.anki_object)
-        elif not import_config.ignore_deck_movement:
-            self.move_cards_to_deck(deck.anki_dict["id"])
+            if saner_note_addition:
+                collection.add_note(self.anki_object, deck.anki_dict["id"])
+            else:
+                self.anki_object.flush()
+                collection.addNote(self.anki_object)
+        else:
+            self.anki_object.flush()
+            if not import_config.ignore_deck_movement:
+                self.move_cards_to_deck(deck.anki_dict["id"])
 
     def handle_import_config_changes(self, import_config, note_model):
         # Personal Fields

--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -105,18 +105,6 @@ class Note(JsonSerializableAnkiObject):
 
         note_model = deck.metadata.models[self.note_model_uuid]
 
-        # Anki 2.1.28 made addition of notes slightly saner
-        # TODO: Refactor once compatibility with 2.1.26 is not needed.
-        # (2.1.27 doesn't seem to have existed.)
-        saner_note_addition = int(anki.version.split(".")[-1]) > 26
-
-        if not saner_note_addition:
-            # You may ask WTF? Well, it seems anki has 2 ways to identify deck where to place card:
-            # 1) Looking for existing cards of this note
-            # 2) Looking at model->did and to add new cards to correct deck we need to modify the did each time
-            # ;(
-            note_model.anki_dict["did"] = deck.anki_dict["id"]
-
         self.anki_object = UuidFetcher(collection).get_note(self.get_uuid())
         new_note = self.anki_object is None
         if new_note:
@@ -131,11 +119,7 @@ class Note(JsonSerializableAnkiObject):
         self.anki_object.mod = anki.utils.intTime()
 
         if new_note:
-            if saner_note_addition:
-                collection.add_note(self.anki_object, deck.anki_dict["id"])
-            else:
-                self.anki_object.flush()
-                collection.addNote(self.anki_object)
+            collection.add_note(self.anki_object, deck.anki_dict["id"])
         else:
             self.anki_object.flush()
             if not import_config.ignore_deck_movement:

--- a/crowd_anki/representation/note_model.py
+++ b/crowd_anki/representation/note_model.py
@@ -40,7 +40,7 @@ class NoteModel(JsonSerializableAnkiDict):
         note_model_dict = UuidFetcher(collection).get_model(self.get_uuid()) or \
                           collection.models.new(self.anki_dict["name"])
 
-        new_model = note_model_dict["id"] is None
+        new_model = not note_model_dict["id"]
 
         self.anki_dict = utils.merge_dicts(note_model_dict, self.anki_dict)
 

--- a/crowd_anki/representation/note_model.py
+++ b/crowd_anki/representation/note_model.py
@@ -40,7 +40,7 @@ class NoteModel(JsonSerializableAnkiDict):
         note_model_dict = UuidFetcher(collection).get_model(self.get_uuid()) or \
                           collection.models.new(self.anki_dict["name"])
 
-        new_model = not note_model_dict["id"]
+        new_model = note_model_dict["id"] == 0
 
         self.anki_dict = utils.merge_dicts(note_model_dict, self.anki_dict)
 


### PR DESCRIPTION
Fix #92.

1. Adjust check for "nullness" of model id

    Previously, a new model had an id of None, now it's 0.

    See: `pylib/anki/media.py:171` in Anki itself (commit [f637ac957d206ead619d54d6cf86eb8958ea508c](https://github.com/ankitects/anki/commit/f637ac957d206ead619d54d6cf86eb8958ea508c#diff-843409f4d10c2ee6d8d4e09ea1fcc80bL171)).

2. Pass deck to `collection.decks.save()`

    It's now required.

3. Update note addition for Anki 2.1.28 and later

    `col.addNote()` is legacy.

    `note.flush()` is now impossible (and unnecessary) for a new note.

<hr/>

I've written this in a way to preserve compatibility with Anki 2.1.26 (and presumably earlier), since this made it easier to interactively test that behaviour was preserved.

This slightly complicates the code, so might not be desirable.

<hr/>

I think that the fix is correct (it seems to work for me, for both importing a fresh CrowdAnki deck and updating an existing one, for Anki 2.1.28, 2.1.34 and 2.1.35), but I'm not sure, as I'm not too familiar with either CrowdAnki or Anki's Note management (pre- or post- overhaul).

(`pipenv run mamba ./` resulted in no errors.)