### PR TITLE
Make uuids persistent when exporting with Anki 2.1.35 (≥ 2.1.28)

### DIFF
--- a/crowd_anki/export/anki_exporter.py
+++ b/crowd_anki/export/anki_exporter.py
@@ -27,7 +27,7 @@ class AnkiJsonExporter(DeckExporter):
         self.deck_name_sanitizer = deck_name_sanitizer
         self.deck_file_name = deck_file_name
         self.note_sorter = NoteSorter(config)
-    
+
     def export_to_directory(self, deck: AnkiDeck, output_dir=Path("."), copy_media=True, create_deck_subdirectory=True) -> Path:
         deck_directory = output_dir
         if create_deck_subdirectory:
@@ -58,13 +58,13 @@ class AnkiJsonExporter(DeckExporter):
     def _save_changes(self, deck, is_export_child=False):
         """Save updates that were made during the export. E.g. UUID fields
 
-It saves decks, deck configurations and models.
+        It saves decks, deck configurations and models.
 
-is_export_child refers to whether this deck is a child for the
-_purposes of the current export operation_.  For instance, if we're
-exporting or snapshotting a specific subdeck, then it's considered the
-"parent" here.  We need the argument to avoid duplicately saving deck
-configs and note models.
+        is_export_child refers to whether this deck is a child for the
+        _purposes of the current export operation_.  For instance, if
+        we're exporting or snapshotting a specific subdeck, then it's
+        considered the "parent" here.  We need the argument to avoid
+        duplicately saving deck configs and note models.
 
         """
 

--- a/crowd_anki/export/anki_exporter.py
+++ b/crowd_anki/export/anki_exporter.py
@@ -48,21 +48,25 @@ class AnkiJsonExporter(DeckExporter):
                                        indent=4,
                                        ensure_ascii=False))
 
-        self._save_changes()
+        self._save_changes(deck)
 
         if copy_media:
             self._copy_media(deck, deck_directory)
 
         return deck_directory
 
-    def _save_changes(self):
-        """Save updates that were maid during the export. E.g. UUID fields"""
-        # This saves decks and deck configurations
-        self.collection.decks.save()
-        self.collection.decks.flush()
+    def _save_changes(self, deck):
+        """Save updates that were made during the export. E.g. UUID fields"""
+        # This saves decks, deck configurations and models
 
-        self.collection.models.save()
-        self.collection.models.flush()
+        # TODO ensure that this works correctly for subdecks
+        self.collection.decks.save(deck.anki_dict)
+
+        for deck_config in deck.metadata.deck_configs.values():
+            self.collection.decks.save(deck_config.anki_dict)
+
+        for model in deck.metadata.models.values():
+            self.collection.models.save(model.anki_dict)
 
         # Notes?
 


### PR DESCRIPTION
Fix #109.

The issue was that col.decks.save() and col.models.save() now require an argument — using them without an argument has no effect.

<hr/>

### Slight issue with children

There's still a slight, partial issue related to the export of decks which have subdecks, but it seems that it was also present when exporting with Anki 2.1.26 and it only occurs for the very first export.  It's a matter of a uuid being generated for the same deck config (assuming that the parent and child decks share it) when dealing with each of the parent and child decks (it's not saved in between), so phantom copies of the deck config are created in `deck.json`.  The `deck_config_uuid` that persists is the one that was last applied.  After the first export, all the phantom copies are cleared out and all the (sub)decks that should share a deck config do indeed have the same `deck_config_uuid`.  

I'll try to fix this, as well, eventually, but since it was already previously present, it's *far* less urgent and I'm not sure how much time I'll have, I think that it's definitely worth merging the current PR (obviously after addressing any feedback) without a fix for this.