### PR TITLE
Gitignore "user-generated" snapshots in user_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,8 @@ fabric.properties
 # Project specific stuff
 crowd_anki/thirdparty
 crowd_anki/meta.json
+crowd_anki/user_files/*
+!crowd_anki/user_files/README.md
 
 .vscode
 .pylintrc

--- a/crowd_anki/user_files/README.md
+++ b/crowd_anki/user_files/README.md
@@ -1,5 +1,5 @@
 This folder is a default location for deck-repositories.
 
-According to https://apps.ankiweb.net/docs/addons.html#userfiles it should not be deleted on plugin update.
+According to https://addon-docs.ankiweb.net/#/more?id=user-files it should not be deleted on plugin update.
 
 You can configure a different one in plugin settings.


### PR DESCRIPTION
This is useful when running CrowdAnki from git, for instance for testing.