### PR TITLE
Implement several new export sort methods (for discussion)

### DIFF
--- a/crowd_anki/config/config_settings.py
+++ b/crowd_anki/config/config_settings.py
@@ -14,6 +14,7 @@ class NoteSortingMethods(Enum):
     GUID = "guid"
     FLAG = "flag"
     TAG = "tag"
+    NOTE_ID = "note_id"
     NOTE_MODEL_NAME = "note_model_name"
     NOTE_MODEL_ID = "note_model_id"
 

--- a/crowd_anki/config/config_settings.py
+++ b/crowd_anki/config/config_settings.py
@@ -12,6 +12,7 @@ class NoteSortingMethods(Enum):
     FIELD1_N = "field1_numeric"
     FIELD2 = "field2"
     FIELD_LAST = "field_last"
+    BROWSER_SORT_FIELD = "browser_sort_field"
     NO_SORTING = "none"
     GUID = "guid"
     FLAG = "flag"

--- a/crowd_anki/config/config_settings.py
+++ b/crowd_anki/config/config_settings.py
@@ -9,12 +9,14 @@ ConfigEntry = namedtuple("ConfigEntry", ["config_name", "default_value"])
 
 class NoteSortingMethods(Enum):
     FIELD1 = "field1"
+    FIELD1_N = "field1_numeric"
     FIELD2 = "field2"
     FIELD_LAST = "field_last"
     NO_SORTING = "none"
     GUID = "guid"
     FLAG = "flag"
     TAG = "tag"
+    TAG_N = "tag_numeric"
     NOTE_ID = "note_id"
     NOTE_MODEL_NAME = "note_model_name"
     NOTE_MODEL_ID = "note_model_id"

--- a/crowd_anki/config/config_settings.py
+++ b/crowd_anki/config/config_settings.py
@@ -10,6 +10,7 @@ ConfigEntry = namedtuple("ConfigEntry", ["config_name", "default_value"])
 class NoteSortingMethods(Enum):
     FIELD1 = "field1"
     FIELD2 = "field2"
+    FIELD_LAST = "field_last"
     NO_SORTING = "none"
     GUID = "guid"
     FLAG = "flag"

--- a/crowd_anki/export/note_sorter.py
+++ b/crowd_anki/export/note_sorter.py
@@ -11,6 +11,7 @@ class NoteSorter:
         NoteSortingMethods.GUID: lambda i: i.anki_object.guid,
         NoteSortingMethods.FLAG: lambda i: i.anki_object.flags,
         NoteSortingMethods.TAG: lambda i: i.anki_object.tags,
+        NoteSortingMethods.NOTE_ID: lambda i: i.anki_object.id,
         NoteSortingMethods.NOTE_MODEL_NAME: lambda i: i.anki_object._model["name"],
         NoteSortingMethods.NOTE_MODEL_ID: lambda i: i.anki_object._model["crowdanki_uuid"],
         NoteSortingMethods.FIELD1: lambda i: i.anki_object.fields[0],

--- a/crowd_anki/export/note_sorter.py
+++ b/crowd_anki/export/note_sorter.py
@@ -1,5 +1,6 @@
 from ..config.config_settings import ConfigSettings, NoteSortingMethods
 
+import re
 
 class NoteSorter:
     sorting_definitions = {
@@ -11,10 +12,12 @@ class NoteSorter:
         NoteSortingMethods.GUID: lambda i: i.anki_object.guid,
         NoteSortingMethods.FLAG: lambda i: i.anki_object.flags,
         NoteSortingMethods.TAG: lambda i: i.anki_object.tags,
+        NoteSortingMethods.TAG_N: lambda i: NoteSorter.numeric_list(i.anki_object.tags),
         NoteSortingMethods.NOTE_ID: lambda i: i.anki_object.id,
         NoteSortingMethods.NOTE_MODEL_NAME: lambda i: i.anki_object._model["name"],
         NoteSortingMethods.NOTE_MODEL_ID: lambda i: i.anki_object._model["crowdanki_uuid"],
         NoteSortingMethods.FIELD1: lambda i: i.anki_object.fields[0],
+        NoteSortingMethods.FIELD1_N: lambda i: NoteSorter.numeric_list(i.anki_object.fields[0]),
         NoteSortingMethods.FIELD2: lambda i: i.anki_object.fields[1],
         NoteSortingMethods.FIELD_LAST: lambda i: i.anki_object.fields[-1]
     }
@@ -43,3 +46,30 @@ class NoteSorter:
                 for method_name in self.sort_methods
             )
         )
+
+    # premature optimisation?
+    numeric_list_regex = re.compile(r'^([^0-9]*)([0-9]*)(.*)$')
+
+    @staticmethod
+    def numeric_list(s):
+        """Split string into a list of alternating strings and integers.
+
+        The listed strings do not contain any numeric characters.  The
+        integers are non-negative.
+
+        For example, 'section1.42' will return ['section', 1, '.', 42].
+
+        This function is used to allow sorting strings containing numerals
+        more "naturally".
+
+        """
+        m = NoteSorter.numeric_list_regex.match(s)
+        (prefix, integer, suffix) = m.groups()
+        if integer:
+            l = [prefix, int(integer)]
+            if suffix:
+                return l + NoteSorter.numeric_list(suffix)
+            else:
+                return l
+        else:
+            return [prefix]

--- a/crowd_anki/export/note_sorter.py
+++ b/crowd_anki/export/note_sorter.py
@@ -15,7 +15,8 @@ class NoteSorter:
         NoteSortingMethods.NOTE_MODEL_NAME: lambda i: i.anki_object._model["name"],
         NoteSortingMethods.NOTE_MODEL_ID: lambda i: i.anki_object._model["crowdanki_uuid"],
         NoteSortingMethods.FIELD1: lambda i: i.anki_object.fields[0],
-        NoteSortingMethods.FIELD2: lambda i: i.anki_object.fields[1]
+        NoteSortingMethods.FIELD2: lambda i: i.anki_object.fields[1],
+        NoteSortingMethods.FIELD_LAST: lambda i: i.anki_object.fields[-1]
     }
     
     def __init__(self, config: ConfigSettings):

--- a/crowd_anki/export/note_sorter.py
+++ b/crowd_anki/export/note_sorter.py
@@ -19,7 +19,8 @@ class NoteSorter:
         NoteSortingMethods.FIELD1: lambda i: i.anki_object.fields[0],
         NoteSortingMethods.FIELD1_N: lambda i: NoteSorter.numeric_list(i.anki_object.fields[0]),
         NoteSortingMethods.FIELD2: lambda i: i.anki_object.fields[1],
-        NoteSortingMethods.FIELD_LAST: lambda i: i.anki_object.fields[-1]
+        NoteSortingMethods.FIELD_LAST: lambda i: i.anki_object.fields[-1],
+        NoteSortingMethods.BROWSER_SORT_FIELD: lambda i: i.anki_object.fields[i.anki_object._model['sortf']]
     }
     
     def __init__(self, config: ConfigSettings):

--- a/test/export/note_sorter_spec.py
+++ b/test/export/note_sorter_spec.py
@@ -11,6 +11,7 @@ from crowd_anki.export.note_sorter import NoteSorter
 test_guids = ["abc", "bcd", "cde", "def", "efg", "fgh"]
 test_flags = [0, 1, 2, 3, 4, 5]
 test_tags = ["adjectives", "directions", "interesting", "nouns", "verbs", "zzzzFinal"]
+test_note_ids = test_flags
 test_notemodels = ["Default", "LL Noun", "LL Sentence", "LL Verb", "LL Word", "Zulu"]
 test_notemodelids = test_guids
 test_fields = test_tags
@@ -19,6 +20,7 @@ note_sorting_single_result_pairs = [
     (NoteSortingMethods.GUID, test_guids),
     (NoteSortingMethods.FLAG, test_flags),
     (NoteSortingMethods.TAG, test_tags),
+    (NoteSortingMethods.NOTE_ID, test_note_ids),
     (NoteSortingMethods.NOTE_MODEL_NAME, test_notemodels),
     (NoteSortingMethods.NOTE_MODEL_ID, test_notemodelids),
     (NoteSortingMethods.FIELD1, test_fields),
@@ -43,6 +45,7 @@ class NoteSorterTester:
         note.anki_object.guid = test_guids[i]
         note.anki_object.flags = test_flags[i]
         note.anki_object.tags = test_tags[i]
+        note.anki_object.id = test_note_ids[i]
 
         note.anki_object._model = {
             "name": test_notemodels[i],

--- a/test/export/note_sorter_spec.py
+++ b/test/export/note_sorter_spec.py
@@ -24,7 +24,8 @@ note_sorting_single_result_pairs = [
     (NoteSortingMethods.NOTE_MODEL_NAME, test_notemodels),
     (NoteSortingMethods.NOTE_MODEL_ID, test_notemodelids),
     (NoteSortingMethods.FIELD1, test_fields),
-    (NoteSortingMethods.FIELD2, test_fields)
+    (NoteSortingMethods.FIELD2, test_fields),
+    (NoteSortingMethods.FIELD_LAST, test_fields)
 ]
 
 test_multikey_notemodel_guid = [(notemodel, guid) for notemodel in test_notemodels for guid in test_guids]

--- a/test/export/note_sorter_spec.py
+++ b/test/export/note_sorter_spec.py
@@ -18,6 +18,7 @@ test_notemodels = ["Default", "LL Noun", "LL Sentence", "LL Verb", "LL Word", "Z
 test_notemodelids = test_guids
 test_fields = test_tags
 test_fields_numeric = test_tags_numeric
+test_sortf = [0] * 6
 
 note_sorting_single_result_pairs = [
     (NoteSortingMethods.GUID, test_guids),
@@ -30,7 +31,8 @@ note_sorting_single_result_pairs = [
     (NoteSortingMethods.FIELD1, test_fields),
     (NoteSortingMethods.FIELD1_N, test_fields_numeric),
     (NoteSortingMethods.FIELD2, test_fields),
-    (NoteSortingMethods.FIELD_LAST, test_fields)
+    (NoteSortingMethods.FIELD_LAST, test_fields),
+    (NoteSortingMethods.BROWSER_SORT_FIELD, test_fields)
 ]
 
 test_multikey_notemodel_guid = [(notemodel, guid) for notemodel in test_notemodels for guid in test_guids]
@@ -55,7 +57,8 @@ class NoteSorterTester:
 
         note.anki_object._model = {
             "name": test_notemodels[i],
-            "crowdanki_uuid": test_notemodelids[i]
+            "crowdanki_uuid": test_notemodelids[i],
+            "sortf": test_sortf[i]
         }
 
         note.anki_object.fields = [test_fields[i], test_fields[i]]

--- a/test/export/note_sorter_spec.py
+++ b/test/export/note_sorter_spec.py
@@ -10,20 +10,25 @@ from crowd_anki.export.note_sorter import NoteSorter
 
 test_guids = ["abc", "bcd", "cde", "def", "efg", "fgh"]
 test_flags = [0, 1, 2, 3, 4, 5]
-test_tags = ["adjectives", "directions", "interesting", "nouns", "verbs", "zzzzFinal"]
+test_tags = ["adjectives", "directions10", "directions2", "nouns", "verbs", "zzzzFinal"]
+test_tags_numeric = [["adjectives"], ["directions", 2], ["directions", 10], ["nouns"],
+                     ["verbs"], ["zzzzFinal"]]
 test_note_ids = test_flags
 test_notemodels = ["Default", "LL Noun", "LL Sentence", "LL Verb", "LL Word", "Zulu"]
 test_notemodelids = test_guids
 test_fields = test_tags
+test_fields_numeric = test_tags_numeric
 
 note_sorting_single_result_pairs = [
     (NoteSortingMethods.GUID, test_guids),
     (NoteSortingMethods.FLAG, test_flags),
     (NoteSortingMethods.TAG, test_tags),
+    (NoteSortingMethods.TAG_N, test_tags_numeric),
     (NoteSortingMethods.NOTE_ID, test_note_ids),
     (NoteSortingMethods.NOTE_MODEL_NAME, test_notemodels),
     (NoteSortingMethods.NOTE_MODEL_ID, test_notemodelids),
     (NoteSortingMethods.FIELD1, test_fields),
+    (NoteSortingMethods.FIELD1_N, test_fields_numeric),
     (NoteSortingMethods.FIELD2, test_fields),
     (NoteSortingMethods.FIELD_LAST, test_fields)
 ]


### PR DESCRIPTION
This is a draft based on the discussion in #107 and #108.

I've implemented several new potential sort methods:

1. Sorting by note id. (#108) (`note_id`)
2. Sorting by the last field. (`field_last`)
3. Sorting tags or the first field "naturally"/"numerically" (such that `1 < 2 < 10`, and `chapter1.1 < chapter1.2 < chapter1.10 < chapter2`).  (`field1_numeric`, `tag_numeric`).
4. Sorting by the [sort field](https://docs.ankiweb.net/#/editing?id=customizing-fields) (as specified by `sortf` in the respective note model(s)). (`browser_sort_field`)

For slightly more extensive descriptions and analyses of drawbacks, see below.

They're all independent, though to some extent they could be combined (in particular **3** can be combined with **2** or **4**).  I'm implementing them in a single PR, because they're all motivated by the same goal of allowing the creators of a deck to control the order in which the learner sees new notes and to avoid an excessively fragmented discussion.

I don't think that they should necessarily all be introduced, so
please feel completely free to shoot down any or all of them.

### Background

As @sudomain had brought up in #107, it's sometimes crucial for new cards/notes to be seen in a specific order, because the "later" notes build on the "earlier" ones.  This is both true when the Anki deck "accompanies" an external learning resource (e.g. a course or a book) and when it's used for standalone learning.  In other cases forcing the order is not essential, but might still be valuable.

If the deck configuration uses the ["Show new cards in order added" option](https://docs.ankiweb.net/#/deck-options?id=new-cards) (Deck `Options` > `New cards` > `Order`), specified in a `deck.json` in the relevant config in `deck_configurations`, by the `order` (`0` means in random order, `1` in order added), then any new cards will be shown in the order in which they're in the `deck.json` (since `CrowdAnki` adds the cards in order).  Hence, by controlling the export order one can control the order in which learners see new cards.

(Note: I haven't checked how this interacts with sub-decks in the beta "Anki 2.1 scheduler" — i.e. whether CrowdAnki imports sub-decks before or after the parent deck.  In any case, though, the order within a subdeck will be as exported.)

### Shortcomings of current sort methods

(This is not intended to be a criticism of the current methods — AFAICT they were mainly created to ensure a stable export with no spurious diffs and to better inter-operate with tools like `BrainBrew`, which they do admirably.)

#### String comparison

`field1`, `field2` and `tag` compare their contents using a string comparison, such that, say, `"2" > "10"`.  

If we wanted to have an "index"/"sort" field to specify the desired order, then simply using consecutive, unpadded integers wouldn't work, since `"10"` would come before `"2"` etc.  Padding the integers with leading zeros, to the same length (e.g. `"002"`, `"100"`) is a solution, but it's non-obvious, slightly ugly and very inconvenient (ensuring consistency when the order of magnitude of the number of cards changes would be particularly annoying).  One could use an additional tool (potentially `BrainBrew` and a spreadsheet, or a dedicated Anki addon), but that's suboptimal.

The same holds for tags — it'd be nice to be able to just tag cards as, say, `deck_name::sectionX.Y.Z`, where X, Y and Z are integers, without having to pad the integers with the correct number of zeros, guessed in advance (renaming tags in Anki can be a pain...).

#### Position of fields

As @sudomain pointed out, it can be annoying for the index field to take the highly prominent first (or second) position — these should be reserved for the actual content of the note.

#### Non-sorting tags

For instance, if we have both "sorting" tags (say `deck_name::chapterX.Y` or `deck_name::sectionX.Y`) and "non-sorting" ones (say `deck_name::hard`, `deck_name::extra_material`, `deck_name::verb`, `deck_name::noun`, `deck_name::europe` etc.), we don't want the presence or absence of the non-sorting tags to influence the sort order.  

If the "non-sorting" tags come after the "sorting" tags alphabetically, then they'll be placed later in the `anki_object.tags` concatenated string and hence have negligible influence, but ensuring that that's always the case might be annoying.  

One can work around this by futher namespacing the sorting and non-sorting tags to enforce correct alphabetical order — having say `deck_name::index::sectionX.Y` and `deck_name::topic::verb` — but it's a bit ugly (and non-obvious, in advance), so it's still not a perfect solution.

#### Ease of use

Having to tag or index all notes can be rather inconvenient.

### Analysis of suggested sort methods

#### Note id

FWIW it seems that Anki's internal note sort order is by id (currently — AFAIK you shouldn't rely on any sort order, if it's not explicitly specified in the [SQL query](https://github.com/Stvad/CrowdAnki/blob/a583fa8ceaa4932cf00630476e357ef2e420233e/crowd_anki/anki/overrides/decks.py#L17)), even if you manually change the id of a note, so `note_id` has (currently) exactly the same effect as the `none` sort method.

Advantages:

1. Easy to get the right order in the first pass (just create the notes in the correct order).
2. With the [Change Card Creation Times](https://ankiweb.net/shared/info/217650262) suggested by @sudomain, one can edit the `note` `id`, hence changing the order.
3. Easy to understand — Anki's new cards' sort order in the creator's deck maps onto the sort order in the learners' deck.

Disadvantages:

1. `CrowdAnki` obviously does not export the `note_id`, meaning that different people will have different `note_id`s and most importantly, changes to the order of `note_id`s won't be shared between contributors, meaning that only one person would be able to change not order...

    @sudomain has a [semi-solution](https://github.com/Stvad/CrowdAnki/issues/108#issuecomment-733701695), but it's still non-ideal.

2. Editing the `note_id`s is impossible without an add-on.

3. Changing `note_id`s feels a bit brittle.

4. Currently, it's equivalent to the "`none`" sort method.

    However, since modifications to `CrowdAnki`'s internals or Anki might change that, it might be worth having a sort order that is *explicitly* by note id.

#### Last field

The obvious advantage is that a potential "index" field will no longer be in a prominent position.  Such an index field can be simply appended to all note types used in the deck.

Sorting by `field_last` is unlikely to have any applications other than for an index field, though.

#### "Natural/numeric sort"

As described above it allows sorting fields containing numbers "naturally", such that `1 < 2 < 10`, and `chapter1.1 < chapter1.2 < chapter1.10 < chapter2`.

The idea is that the string is split into a list of alternating strings containing no numeric characters and non-negative integers.  Python happily sorts lists (even lists of variable length, provided that all corresponding fields are comparable), so this allows us to sort in a way where integers are compared as integers, not as strings.

(Note that since we're dealing purely with non-negative integers, not decimals, `"1.5" < "1.10"` etc., which in the context of strings using schemas like `sectionX.Y` makes perfect sense, but might be confusing under some other conditions.)

It's very similar to the "version" sort in GNU `ls` and `sort`  (`ls -v` and `sort -V`), which use the gnulib `filevercmp` function.

Obviously, this type of sort can (and if decided to be generally a good idea, probably should) be combined with more of the existing and new methods (`field2`, `field_last`, `sort_field`).

I'm extremely unhappy about the names (`field1_numeric`, `tag_numeric`) and would welcome any alternative suggestions.

#### Sorting by the "sort field"

The advantage is that this allows sorting the export, by the field that appears [in the Sort Field column of the browser](https://docs.ankiweb.net/#/editing?id=customizing-fields), and hence the export order can be the same as the default sort order in the browser.

It feels neat, but a bit gimmicky, so I'm not sure if it's worth introducing.

I'm also rather unhappy about the name (`browser_sort_field`...).

### Wishlist

#### Sorting by only a subset of tags.  

As described above there's the issue of "non-sorting tags" potentially interfering with sorting tags.  None of the above proposals deal with this.  I can't think of any way of solving it that either doesn't involve hardcoding keywords (such as `section` or `chapter`), hence losing flexibility, or considerably overhauling the entire system (having per-deck sorting, with configurable keywords).

### Doubts

#### Tests

Should the export sort tests be more discriminating?  The currently existing tests don't really distinguish between `field1`, `field2` and `tag` (so for instance if somebody changed one of relevant indices in `note_sorter.py`, it wouldn't be caught).  The newly added tests further don't distinguish between `browser_sort_field`, `field_last` and `field1` etc.

However, the tests will catch many forms of breakage, so it might not be worth over-complicating the test lists.  Also, the most likely source of breakage is Anki's internals changing, which wouldn't be caught here, anyway...

#### Flag

The current sort by flag feels rather weird.  Notes can have a flag (it's present in the database in the `notes` table), but [Anki's source states](https://github.com/ankitects/anki/blob/master/pylib/anki/notes.py#L17) that they're "not currently exposed", CrowdAnki doesn't export or import them, and I don't think that they even influence the result of a "`flag`" sort...

(The commonly encountered per-card flags have no bearing on the note flags.)

#### Naming

As mentioned above, I'd greatly welcome alternative names for most of the proposed sort methods.