### PR TITLE
Close and reopen the collection before/after pre-import backup

### DIFF
--- a/crowd_anki/importer/anki_importer.py
+++ b/crowd_anki/importer/anki_importer.py
@@ -33,7 +33,9 @@ class AnkiJsonImporter:
             return False
 
         if aqt.mw:
+            aqt.mw.col.close(downgrade=False)
             aqt.mw.backup()
+            aqt.mw.col.reopen(after_full_sync=False)
         try:
             deck = deck_initializer.from_json(deck_json)
             deck.save_to_collection(self.collection, import_config=import_config)


### PR DESCRIPTION
See https://github.com/axelboc/anki-ultimate-geography/issues/392.

Without this (or another fix) import fails for Anki ≥ 2.1.40.

The commit in Anki that caused the crash is [`b7c72bca4c3503196ed8cfb8e15ad78e6243144d`](https://github.com/ankitects/anki/commit/b7c72bca4c3503196ed8cfb8e15ad78e6243144d).

### Correctness?

I'm not sure whether the fix here is the "right one". It fixes the issue, doesn't seem to cause any major slow-down and to the extent that I can tell, it makes sense, but I'm not certain.

It will (almost certainly) result in a robust back-up, since it's the steps used by Anki itself for the backup before a full sync, but it might be overkill.