### PR TITLE
Avoid storing `deck_config_uuid` in Anki db and deal with fallout

### DIFF
--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -83,6 +83,12 @@ class Deck(JsonSerializableAnkiDict):
         new_config = DeckConfig.from_collection(self.collection, self.anki_dict["conf"])
         self.deck_config_uuid = new_config.get_uuid()
 
+        # TODO Remove this once enough time has passed that #106/#116
+        # is no longer an issue — i.e. when there are likely no more
+        # Anki dbs with a `deck_config_uuid` attached to the deck.
+        if "deck_config_uuid" in self.anki_dict:
+            del self.anki_dict["deck_config_uuid"]
+
         self.metadata.deck_configs.setdefault(new_config.get_uuid(), new_config)
 
     def serialization_dict(self):

--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -87,6 +87,7 @@ class Deck(JsonSerializableAnkiDict):
         # TODO Remove this once enough time has passed that #106/#116
         # is no longer an issue — i.e. when there are likely no more
         # Anki dbs with a `deck_config_uuid` attached to the deck.
+        # See #133.
         if "deck_config_uuid" in self.anki_dict:
             del self.anki_dict["deck_config_uuid"]
 
@@ -184,6 +185,7 @@ class Deck(JsonSerializableAnkiDict):
             # TODO Remove the exception-handling once we're confident
             # that there are no more buggy decks, with mismatching
             # `deck_config_uuid`s.
+            # See #133.
         except KeyError as error:
             AnkiModalNotifier().error("Incorrect deck config",
                                       "The deck config uuid {} is not present in the deck. "

--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -36,7 +36,8 @@ class Deck(JsonSerializableAnkiDict):
                          "deck_configurations",
                          "children",
                          "media_files",
-                         "notes"}
+                         "notes",
+                         "deck_config_uuid"}
 
     def __init__(self,
                  file_provider_supplier: Callable[[Any, Iterable[int]], FileProvider],

--- a/crowd_anki/representation/deck_initializer.py
+++ b/crowd_anki/representation/deck_initializer.py
@@ -44,7 +44,6 @@ def from_json(json_dict, deck_metadata=None) -> Deck:
     deck.notes = [Note.from_json(json_note) for json_note in json_dict["notes"]]
     deck.children = [from_json(child, deck_metadata=deck.metadata) for child in json_dict["children"]]
 
-    # Todo should I call this here?
     deck.post_import_filter()
 
     return deck


### PR DESCRIPTION
Fix #106, fix #116, fix #61.

Due to the fact that the `deck_config_uuid` is imported by `CrowdAnki` into the Anki database as a property of the deck (in the `decks` table, at least in later versions of Anki), but not updated when the options group (Deck config) is changed, and due to the order of keys in `crowd_anki/representation/json_serializable.py` (`deck.anki_dict["deck_config_uuid"]` (with the stale/hardcoded `deck_config_uuid`) overrides `deck.deck_config_uuid` (which is fetched on demand, using `Deck._load_deck_config`) during export), a `deck.json` file with a deck whose `deck_config_uuid` points towards a Deck config that's not actually present in `deck_configurations` can be created. This obviously results in an error when a user tries to import the deck.

<hr/>

The reproduction steps are:

1. Start with a fresh profile.
2. Create a deck (say `foo`) with a couple of notes.
3. Create a new deck config (options group), say `new_options`, via the standard: `Options` > `Options group` > `Manage...` > `Add` and switch back to `Default`.

    Note that this has to be done at this stage, rather than later, otherwise we're confounded by #118.
    
4. Export `foo` with CrowdAnki.
5. Re-import `foo` with CrowdAnki.
6. Change the options group of `foo` from `Default` to `new_options`.
7. Export `foo` with CrowdAnki.
8. Try re-importing `foo`.

Expected result: All the imports and exports work fine.

Actual result: The final import fails with a `KeyError` (due to the mismatching `deck_config_uuid`).

<hr/>


I discussed some possible solutions [here](https://github.com/Stvad/CrowdAnki/issues/106#issuecomment-723312413).

After some thought, I think that the `deck_config_uuid` should simply not be stored in the Anki db (i.e. **2** from the linked comment). It duplicates the information present in the `conf` key in the db. [We already (sensibly) strip](https://github.com/Stvad/CrowdAnki/blob/117a2946aeeed00abf2b90430b70073636a66d3f/crowd_anki/representation/deck.py#L35) `note_models` or `children` from the deck object before writing it into the Anki db and there's no reason for `deck_config_uuid` to be different. (That's the first commit.)

Unfortunately, this will only prevent the issue from coming up in the future, for people with fresh Anki profiles and creating new decks. We'd still be left with:

1. Many deck maintainers/contributors with the `deck_config_uuid` still stored in the Anki database, attached to the Anki deck object.
   This means that if they ever change the options group of a deck with such a stale `deck_config_uuid`, and export it, we'll again have a broken `deck.json`.
2. There are probably broken exported `deck.json`s out there, which will crash users' Ankis if imported.
   IMO this is far less pressing than 1., because it's easy to notice and diagnose.

The second commit deals with 1. — it (permanently) removes the `deck_config_uuid` from the given deck's `anki_dict` when exporting that deck. (I thought about removing `deck_config_uuid`s from all decks, on `CrowdAnki` startup, but I think that that's too risky and invasive.) It can hopefully be removed in a year and so, once we're sure that we've cleared out all the `deck_config_uuid`s from (most) users' databases.

The third commit tries to deal with 2., by providing a modal popup with some info. I'm not sure if it's helpful or necessary, though.

<hr/>
    
    
We've been pretty lucky that we also have issue #118, as it's considerably mitigated #106/#116. #118 causes different deck configs to have the same `crowdanki_uuid`, so even though the `deck_config_uuid` is not updated when the deck config is changed, it doesn't matter, because both the "right" and the "wrong" `deck_config_uuid`s are the same. (In that it matters to the extent that the wrong deck config is probably exported, but at least import doesn't cause a crash.)

<hr/>

### Summary

Stale `deck_config_uuid` can cause broken `deck.json`s. (The `deck_config_uuid` is not among the `crowdanki_uuid`s of the deck configs in `deck_configurations`.)

1. `4ec62298` prevents the `deck_config_uuid` from being stored in the Anki database during import. (The `deck_config_uuid` duplicates the deck's `conf` and the deck config's `crowdanki_uuid`, so it's not really useful, but as noted above, can be harmful.)
2. `e8fa915f` removes the `deck_config_uuid` where it's already present in the database, during export.
3. `e8dca2f7` provides the end-user with some info if they do encounter a broken `deck.json` during import. I'm not sure if it actually adds any value.

**1** resolves the initial bug, **2** and **3** deal with the "fallout".