### PR TITLE
Prevent crash when trying to export all decks

### DIFF
--- a/crowd_anki/utils/notifier.py
+++ b/crowd_anki/utils/notifier.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
 import aqt.utils
+import aqt
 
 
 class Notifier(ABC):
@@ -16,16 +17,27 @@ class Notifier(ABC):
     def error(self, title: str, message: str):
         pass
 
+def run_closure_in_main(closure):
+    """Run the closure in the main thread.
+
+This is necessary, because GUI operations in a background thread cause
+a crash.  For instance, export is now run in a background thread.
+
+    """
+    if aqt.mw.inMainThread():
+        closure()
+    else:
+        aqt.mw.taskman.run_on_main(lambda: aqt.mw.progress.timer(50, closure, False))
 
 class AnkiModalNotifier(Notifier):
     def info(self, title: str, message: str):
-        aqt.utils.showInfo(message, title=title)
+        run_closure_in_main(lambda: aqt.utils.showInfo(message, title=title))
 
     def warning(self, title: str, message: str):
-        aqt.utils.showWarning(message, title=title)
+        run_closure_in_main(lambda: aqt.utils.showWarning(message, title=title))
 
     def error(self, title: str, message: str):
-        aqt.utils.showCritical(message, title=title)
+        run_closure_in_main(lambda: aqt.utils.showCritical(message, title=title))
 
 
 class AnkiTooltipNotifier(Notifier):

--- a/crowd_anki/utils/notifier.py
+++ b/crowd_anki/utils/notifier.py
@@ -27,7 +27,7 @@ a crash.  For instance, export is now run in a background thread.
     if aqt.mw.inMainThread():
         closure()
     else:
-        aqt.mw.taskman.run_on_main(lambda: aqt.mw.progress.timer(50, closure, False))
+        aqt.mw.taskman.run_on_main(lambda: aqt.mw.progress.timer(0, closure, False))
 
 class AnkiModalNotifier(Notifier):
     def info(self, title: str, message: str):


### PR DESCRIPTION
Fix #128.

The crash was caused by the warning dialog, itself!  The issue was that export is now run in a background thread, but GUI operations from a background thread cause a crash.

AnkiModalNotifier is used in `anki_exporter_wrapper.py` and `github_importer.py`.  The former is in a background thread, the latter in the main thread.  In both cases, error messages are now correctly displayed, without crashing.

Tested on Anki 2.1.40 and 2.1.43.

For comparison / a similar issue [see](https://anki.tenderapp.com/discussions/ankidesktop/42070-anki-closes-without-warning-when-importing-conflicting-shared-deck).

I'm not very happy about the solution — particularly the timer — but without the timer `run_on_main` results in some sort of weird deadlock and I can't think of a better method.