### PR TITLE
Avoid duplicating crowdanki_uuid when cloning deck config

### DIFF
--- a/crowd_anki/anki/hook_vendor.py
+++ b/crowd_anki/anki/hook_vendor.py
@@ -1,3 +1,5 @@
+from aqt import gui_hooks
+
 from dataclasses import dataclass
 from typing import Any
 
@@ -5,6 +7,7 @@ from ..config.config_settings import ConfigSettings
 from ..anki.adapters.hook_manager import AnkiHookManager
 from ..export.anki_exporter_wrapper import exporters_hook
 from ..history.archiver_vendor import ArchiverVendor
+from ..utils.deckconf import disambiguate_crowdanki_uuid
 
 
 @dataclass
@@ -16,6 +19,7 @@ class HookVendor:
     def setup_hooks(self):
         self.setup_exporter_hook()
         self.setup_snapshot_hooks()
+        self.setup_add_config_hook()
 
     def setup_exporter_hook(self):
         self.hook_manager.hook("exportersList", exporters_hook)
@@ -24,3 +28,6 @@ class HookVendor:
         snapshot_handler = ArchiverVendor(self.window, self.config).snapshot_on_sync
         self.hook_manager.hook('profileLoaded', snapshot_handler)
         self.hook_manager.hook('unloadProfile', snapshot_handler)
+
+    def setup_add_config_hook(self):
+        gui_hooks.deck_conf_did_add_config.append(disambiguate_crowdanki_uuid)

--- a/crowd_anki/utils/deckconf.py
+++ b/crowd_anki/utils/deckconf.py
@@ -1,0 +1,10 @@
+from .constants import UUID_FIELD_NAME
+
+def disambiguate_crowdanki_uuid(deck_conf, deck,
+                                config, new_name,
+                                new_conf_id):
+    new_deck_conf = deck_conf.mw.col.decks.get_config(new_conf_id)
+    if (new_deck_conf and (UUID_FIELD_NAME in new_deck_conf)):
+        # Delete rather than generating anew, (with uuid1()) to avoid code duplication.
+        del new_deck_conf[UUID_FIELD_NAME]
+        deck_conf.mw.col.decks.update_config(new_deck_conf)

--- a/crowd_anki/utils/deckconf.py
+++ b/crowd_anki/utils/deckconf.py
@@ -1,3 +1,7 @@
+# Note that this only works for Anki ≤ 2.1.45, or when using the old
+# deck options popup with Anki 2.1.46+.  Anki 2.1.46+ has a new
+# JavaScript-based options popup (with no hooks), by default.
+
 from .constants import UUID_FIELD_NAME
 
 def disambiguate_crowdanki_uuid(deck_conf, deck,


### PR DESCRIPTION
Please do not merge this before at least the first commit of #127 (this bug (the #118 bug) mitigates the more serious bug that #127 solves)!

Partially deal with #118.

Testing, it seems that I somehow haven't broken the tests despite fiddling with anki/hook_vendor without adding to the overrides.

Note that `deck_conf_did_add_config` is not available as a "legacy" hook, so the new hook mechanism has to be used.  It might (or might not) be worth converting the existing hooks to the new mechanism.

I've chosen to simply delete the `crowdanki_uuid` property from the cloned deck config, rather than immediately regenerate a new uuid, to avoid code duplication — when the new deck config needs a uuid, one will be generated for it, by the standard mechanism.

### Testing

This PR can be tested to show that it works correctly by following the reproduction sequence in #118 or by inspecting the `crowdanki_uuid`s of the deck configs with the debug console:

1. Open the console with <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>;</kbd>.
2. Run the following and check that none of the UUIDs are the same (and are present/absent when expected):

```python3
for c in self.col.decks.all_config():
    if "crowdanki_uuid" in c:
        print(f"{c['crowdanki_uuid']} for {c['name']}")
    else:
        print(f"no uuid for {c['name']}")
```


### Duplicate deck config `crowdanki_uuid`s "in the wild"

There will almost certainly be many cases where users have deck configs with duplicate `crowdanki_uuid` and this PR obviously won't fix that — it'll just prevent more such cases occurring.  Since this is a minor bug, I don't think that it's worth complicating the CrowdAnki codebase by including an automated fixer.

Instead, I'll write a debug console script for diagnosing and fixing this and the other UUID issues.