### PR TITLE
Avoid duplicating crowdanki_uuid when cloning note model

### DIFF
--- a/crowd_anki/anki/overrides/__init__.py
+++ b/crowd_anki/anki/overrides/__init__.py
@@ -6,3 +6,4 @@
 from . import cards
 from . import decks
 from . import exporting
+from . import models

--- a/crowd_anki/anki/overrides/models.py
+++ b/crowd_anki/anki/overrides/models.py
@@ -1,0 +1,37 @@
+import anki.hooks
+from anki.models import ModelManager
+
+from ...utils.constants import UUID_FIELD_NAME
+
+def model_copy(*args, **kwargs):
+    """Override the built-in models.copy.
+
+    Extracting `_old` from `kwargs` is ugly, but allows passing
+    arbitrary arguments to the built-in copy function (`_old()`).  For
+    instance, in Anki 2.1.45, an optional `add` argument is added to
+    `copy`.
+
+    Note that this wrapper won't have any effect if `add=True` is
+    passed to `copy`!  Fortunately, this will only happen if another
+    add-on tries to clone a note model using `models.copy()`.  In Anki
+    itself, only add=False is passed, by design — the idea is that
+    normally the new model is only actually added (once!) to the
+    database in `Models.onAdd` in `qt/aqt/models.py`.
+
+    We could try to special-case `add=True` and call something like
+    `models.add(cloned)` if `add=True`, but it'd make this wrapper
+    more fragile to changes in `copy`, for relatively little gain.
+
+    A more serious problem than another add-on cloning note models is
+    AnkiDroid and AnkiMobile doing so, which we're currently not
+    mitigating.
+
+    """
+    _old = kwargs['_old']
+    del kwargs['_old']
+    cloned = _old(*args, **kwargs)
+    if UUID_FIELD_NAME in cloned:
+        del cloned[UUID_FIELD_NAME]
+    return cloned
+
+ModelManager.copy = anki.hooks.wrap(old=ModelManager.copy, new=model_copy, pos='around')


### PR DESCRIPTION
Fix #121, fix #123.

### Testing

1. Ensure that you have a deck (say `test`) with at least one note of note type (say) `Basic`.
2. Export `test` with CrowdAnki.
3. (Optionally check that the `Basic` note type has been correctly exported, and that in total, one note type has been exported (e.g. use `jq < deck.json '.note_models | length'`).)
4. Create a new note type (`Tools` > `Manage note types` > `Add` > `Clone: Basic` > `OK`), say called `Basic_test`.
5. In the `test` deck create a note of type `Basic_test`.
6. Inspect the exported `deck.json`. (e.g. with `jq < deck.json '.note_models | length'`)

#### Expected result (and the result with this PR)

1. There are two exported note models.

#### Actual result (before this PR)

1. There's only one exported note model.

Alternatively, inspect the note models with a debug console script:

```python3
repeated = {}
for model in filter(lambda model: 'crowdanki_uuid' in model,
                    self.col.models.all()):
    cu = model["crowdanki_uuid"]
    if cu in repeated:
        repeated[cu] = True
    else:
        repeated[cu] = False

if any(repeated.values()):
    print("WARNING! There are repeated Note Model uuids!")
else:
    print("There are no repeated Note Model uuids! Everything is OK!")
```


### Limitations

#### AnkiDroid and AnkiMobile

Unfortunately, this PR does not prevent a user from duplicating a note model's crowdanki_uuid when cloning a note model on AnkiDroid or AnkiMobile.  Hopefully most users create new note models on desktop!

#### Add-ons that clone note models

As described in the relevant docstring, if an add-on clones a note-model with `add=True`, then (on Anki ≥ 2.1.45) we won't catch the duplicated UUID.  (This could be dealt with relatively easily.)

(Looking quickly, it seems that there are cases of add-ons cloning note models:

https://github.com/search?q=models.copy+anki&type=Code )

### Future work

(This is for my own reference, and for informational purposes.)

#### Checking for duplicate `crowdanki_uuid`s during export

It might be worth adding code that checks for duplicate `crowdanki_uuid`s when exporting, in order to deal with the already duplicated `crowdanki_uuid`s in users' databases and those that will be duplicated in the future when duplicating note models on AnkiDroid and AnkiMobile (as described above).  However, that is likely far more complicated to do correctly (how do we determine which is the original note model and which the new one?), so I'll leave it for a future refinement.

#### Debug console script

Also, like mentioned in #135, I'll try to write (ASAP) a debug console script for diagnosing and fixing all the recent `crowdanki_uuid` issues.  

(Alternatively, should we have a menu-item, similar to the built-in `Tools > Check database` for checking the UUID issues?)

#### Checking for issues during import

As discussed in #121 and #123, the duplicate `crowdanki_uuid`s issue leads to incomplete exports of note models.  (`CrowdAnki` thinks that several different note models are the same, so exports only one of them.)  This can be particularly problematic during import if the number of fields of a note doesn't match the number of fields in the (incorrect) note type.

It _might_ be nice to check, during import, that the number of fields in a note matches the number of fields in the note type.

#### Creating a hook

I'll ask upstream (in Anki) whether we could have a hook that runs just before or just after a note model was duplicated (similar to `deck_conf_did_add_config`), in order that we can remove the monkey patching here!