### PR TITLE
Implement part of Github direct upload method

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ dataclasses = "*"
 pygtrie = "*"
 cached-property = "*"
 PyYAML = "*"
+pygithub = "*"
 
 [requires]
 python_version = "3.7"

--- a/crowd_anki/config/config_dialog.py
+++ b/crowd_anki/config/config_dialog.py
@@ -35,11 +35,16 @@ class ConfigDialog(QDialog):
     def ui_initial_setup(self):
         self.setup_snapshot_options()
         self.setup_export_options()
+        self.setup_github_options()
         self.setup_import_options()
 
     def setup_snapshot_options(self):
         self.form.textedit_snapshot_path.setText(self.config.snapshot_path)
         self.form.textedit_snapshot_path.textChanged.connect(self.changed_textedit_snapshot_path)
+
+        self.form.textedit_gh_username.textChanged.connect(self.changed_gh_username)
+        self.form.textedit_gh_password.textChanged.connect(self.changed_gh_password)
+        self.form.textedit_gh_repo.textChanged.connect(self.changed_gh_repo)
 
         self.form.cb_automated_snapshot.setChecked(self.config.automated_snapshot)
         self.form.cb_automated_snapshot.stateChanged.connect(self.toggle_automated_snapshot)
@@ -60,6 +65,20 @@ class ConfigDialog(QDialog):
     def setup_import_options(self):
         self.form.cb_ignore_move_cards.setChecked(self.config.import_notes_ignore_deck_movement)
         self.form.cb_ignore_move_cards.stateChanged.connect(self.toggle_ignore_move_cards)
+
+    def setup_github_options(self):
+        self.form.textedit_gh_username.setText(self.config.gh_username)
+        self.form.textedit_gh_password.setText(self.config.gh_password)
+        self.form.textedit_gh_repo.setText(self.config.gh_repo)
+
+    def changed_gh_username(self):
+        self.config.gh_username = self.form.textedit_gh_username.text()
+    
+    def changed_gh_password(self):
+        self.config.gh_password = self.form.textedit_gh_password.text()
+    
+    def changed_gh_repo(self):
+        self.config.gh_repo = self.form.textedit_gh_repo
 
     def toggle_automated_snapshot(self):
         self.config.automated_snapshot = not self.config.automated_snapshot

--- a/crowd_anki/config/config_settings.py
+++ b/crowd_anki/config/config_settings.py
@@ -33,6 +33,10 @@ class ConfigSettings:
     export_create_deck_subdirectory: bool
     import_notes_ignore_deck_movement: bool
 
+    gh_username: str
+    gh_password: str
+    gh_repo: str
+
     @property
     def formatted_export_note_sort_methods(self) -> list:
         return [
@@ -48,6 +52,10 @@ class ConfigSettings:
         EXPORT_NOTES_REVERSE_ORDER = ConfigEntry("export_notes_reverse_order", False)
         EXPORT_CREATE_DECK_SUBDIRECTORY = ConfigEntry("export_create_deck_subdirectory", True)
         IMPORT_NOTES_IGNORE_DECK_MOVEMENT = ConfigEntry("import_notes_ignore_deck_movement", False)
+
+        GH_USERNAME = ConfigEntry("gh_username", "")
+        GH_PASSWORD = ConfigEntry("gh_password", "")
+        GH_REPO = ConfigEntry("gh_password", "")
 
     def __init__(self, addon_manager=None, init_values=None, profile_manager=None):
         self._profile_manager = profile_manager or mw.pm

--- a/crowd_anki/export/anki_exporter.py
+++ b/crowd_anki/export/anki_exporter.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 from typing import Callable
 
+from github import Github
 
 from .deck_exporter import DeckExporter
 from ..anki.adapters.anki_deck import AnkiDeck
@@ -14,6 +15,7 @@ from ..utils.constants import DECK_FILE_NAME, DECK_FILE_EXTENSION, MEDIA_SUBDIRE
 from ..utils.filesystem.name_sanitizer import sanitize_anki_deck_name
 from .note_sorter import NoteSorter
 from ..config.config_settings import ConfigSettings
+from ..utils.notifier import AnkiModalNotifier, Notifier
 
 
 class AnkiJsonExporter(DeckExporter):
@@ -54,6 +56,71 @@ class AnkiJsonExporter(DeckExporter):
             self._copy_media(deck, deck_directory)
 
         return deck_directory
+    
+    def export_to_github(self, deck: AnkiDeck, user, pass, repo, copy_media=True, create_deck_subdirectory=True, notifier=None):
+    
+        """
+        This utility function directly uploads an AnkiDeck to Github.
+        
+        To authorize it, a username and password must be supplied (note: password should be a Github
+        personal access token from https://github.com/settings/tokens - don't try it using your
+        actual username and password as that would be highly insecure and against best practices.
+        
+        Note: if a file already exists on the repo at the location determined, it will be updated.
+        """
+        
+        deck_directory = ""
+        if create_deck_subdirectory:
+            deck_directory = f"{self.deck_name_sanitizer(deck.name)}/"
+        
+        filename = deck_directory + self.deck_file_name + DECK_FILE_EXTENSION
+        
+        deck = deck_initializer.from_collection(self.collection, deck.name)
+        deck.notes = self.note_sorter.sort_notes(deck.notes)
+        self.last_exported_count = deck.get_note_count()
+        
+        g = Github(user, pass)
+    
+        try:
+            gh_user = g.get_user()
+        except:
+            return notifier.warning("Authentication to Github failed", "Authenticating with Github failed. Please check that "
+                                                                       "both your username and password are correct. Remember: don't use your "
+                                                                       "real Github login password, create a personal access token (https://git.io/token) "
+                                                                       "and use that as the password.")
+    
+        # We find out if the file exists so we can replace it
+        # Code snippet from https://stackoverflow.com/a/63445581, CC-BY-SA
+           
+        try:
+            repo = gh_user.get_repo(GITHUB_REPO)
+        except:
+            return notifier.warning("Unable to find Github repository", "Unable to find your Github repository. Make sure you've created one first: https://repo.new")
+        
+        all_files = []
+        contents = repo.get_contents("")
+        
+        while contents:
+            file_content = contents.pop(0)
+            if file_content.type == "dir":
+                contents.extend(repo.get_contents(file_content.path))
+            else:
+                file = file_content
+                all_files.append(str(file).replace('ContentFile(path="','').replace('")',''))
+                
+        try:
+            if filename in all_files:
+                contents = repo.get_contents(filename)
+                new_contents = json.dumps(deck, default=Deck.default_json, sort_keys=True, indent=4, ensure_ascii=False)
+                repo.update_file(contents.path, "Automated update from CrowdAnki", new_contents, contents.sha, branch = "main")
+            else:
+                new_contents = json.dumps(deck, default=Deck.default_json, sort_keys=True, indent=4, ensure_ascii=False)
+                repo.create_file(filename, "Automated upload from CrowdAnki", new_contents, branch="main")
+        except Exception as e:
+            return notifier.warning("Unknown error when uploading file", "Please report this error at https://git.io/JCUKl.\n\n" + str(e))
+        
+        # Not sure what to return if successful
+        return True
 
     def _save_changes(self, deck, is_export_child=False):
         """Save updates that were made during the export. E.g. UUID fields

--- a/crowd_anki/export/anki_exporter.py
+++ b/crowd_anki/export/anki_exporter.py
@@ -60,7 +60,7 @@ class AnkiJsonExporter(DeckExporter):
     def export_to_github(self, deck: AnkiDeck, user, pass, repo, copy_media=True, create_deck_subdirectory=True, notifier=None):
     
         """
-        This utility function directly uploads an AnkiDeck to Github.
+        This utility function directly uploads an AnkiDeck to Github in the JSON format.
         
         To authorize it, a username and password must be supplied (note: password should be a Github
         personal access token from https://github.com/settings/tokens - don't try it using your

--- a/crowd_anki/export/anki_exporter_wrapper.py
+++ b/crowd_anki/export/anki_exporter_wrapper.py
@@ -1,3 +1,4 @@
+from crowd_anki import config
 from pathlib import Path
 
 from .anki_exporter import AnkiJsonExporter
@@ -39,7 +40,7 @@ class AnkiJsonExporterWrapper:
         self.anki_json_exporter = json_exporter or AnkiJsonExporter(collection, ConfigSettings.get_instance())
         self.notifier = notifier or AnkiModalNotifier()
         
-    def exportToGithub(self, username, password, repo):
+    def exportToGithub(self):
         if self.did is None:
             self.notifier.warning(EXPORT_FAILED_TITLE, "CrowdAnki export works only for specific decks. "
                                                        "Please use CrowdAnki snapshot if you want to export "
@@ -51,8 +52,9 @@ class AnkiJsonExporterWrapper:
             self.notifier.warning(EXPORT_FAILED_TITLE, "CrowdAnki does not support export for dynamic decks.")
             return
         
-        self.anki_json_exporter.export_to_github(deck, username, password, repo, self.includeMedia,
-                                                 create_deck_subdirectory=ConfigSettings.get_instance().export_create_deck_subdirectory)
+        self.anki_json_exporter.export_to_github(deck, ConfigSettings.get_instance().gh_username,
+                                                ConfigSettings.get_instance().gh_password, self.includeMedia,
+                                                ConfigSettings.get_instance().gh_repo, create_deck_subdirectory=ConfigSettings.get_instance().export_create_deck_subdirectory)
         
         self.count = self.anki_json_exporter.last_exported_count
     

--- a/crowd_anki/export/anki_exporter_wrapper.py
+++ b/crowd_anki/export/anki_exporter_wrapper.py
@@ -23,14 +23,39 @@ class AnkiJsonExporterWrapper:
     def __init__(self, collection,
                  deck_id: int = None,
                  json_exporter: AnkiJsonExporter = None,
+                 gh_username: str = None,
+                 gh_password: str = None,
+                 gh_repo: str = None,
                  notifier: Notifier = None):
+           
+        self.gh_username = gh_username
+        self.gh_password = gh_password
+        self.gh_repo = gh_repo
+        
         self.includeMedia = True
         self.did = deck_id
         self.count = 0  # Todo?
         self.collection = collection
         self.anki_json_exporter = json_exporter or AnkiJsonExporter(collection, ConfigSettings.get_instance())
         self.notifier = notifier or AnkiModalNotifier()
+        
+    def exportToGithub(self, username, password, repo):
+        if self.did is None:
+            self.notifier.warning(EXPORT_FAILED_TITLE, "CrowdAnki export works only for specific decks. "
+                                                       "Please use CrowdAnki snapshot if you want to export "
+                                                       "the whole collection.")
+            return
 
+        deck = AnkiDeck(self.collection.decks.get(self.did, default=False))
+        if deck.is_dynamic:
+            self.notifier.warning(EXPORT_FAILED_TITLE, "CrowdAnki does not support export for dynamic decks.")
+            return
+        
+        self.anki_json_exporter.export_to_github(deck, username, password, repo, self.includeMedia,
+                                                 create_deck_subdirectory=ConfigSettings.get_instance().export_create_deck_subdirectory)
+        
+        self.count = self.anki_json_exporter.last_exported_count
+    
     # required by anki exporting interface with its non-PEP-8 names
     # noinspection PyPep8Naming
     def exportInto(self, directory_path):
@@ -48,10 +73,10 @@ class AnkiJsonExporterWrapper:
         # .parent because we receive name with random numbers at the end (hacking around internals of Anki) :(
         export_path = Path(directory_path).parent
         self.anki_json_exporter.export_to_directory(deck, export_path, self.includeMedia,
-                                                    create_deck_subdirectory=ConfigSettings.get_instance().export_create_deck_subdirectory)
+                                                    create_deck_subdirectory=ConfigSettings.get_instance().export_create_deck_subdirectory,
+                                                    notifier=self.notifier)
 
         self.count = self.anki_json_exporter.last_exported_count
-
 
 def get_exporter_id(exporter):
     return f"{exporter.key} (*{exporter.ext})", exporter

--- a/ui_files/config.ui
+++ b/ui_files/config.ui
@@ -59,6 +59,62 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="group_snapshot">
+         <property name="title">
+          <string>Github</string>
+         </property>
+
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="lbl_gh_username">
+              <property name="text">
+               <string>Github username (no @):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="textedit_gh_username"/>
+            </item>
+           </layout>
+          </item>
+
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="lbl_gh_password">
+              <property name="text">
+               <string>Github personal access token (from https://git.io/token):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="textedit_gh_password"/>
+            </item>
+           </layout>
+          </item>
+
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="lbl_gh_repo">
+              <property name="text">
+               <string>Github export repository (from https://repo.new):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="textedit_gh_repo"/>
+            </item>
+           </layout>
+          </item>
+
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="group_deck_import">
          <property name="title">
           <string>Import</string>


### PR DESCRIPTION
This adds some methods into the exporter class and export wrapper class to facilitate the direct export of the JSON representation into Github. It also adds some config entry fields where the user can put their Github [personal access token](https://git.io/token), username and repository name.

This is not ready for merging yet because it does not actually show up in the UI as an export option. I am working on doing this but it will likely require the rewriting of part of the export dialog.

It includes the dependency `PyGithub` because it is much easier to use the API of Github over natively implementing Git through preexisting dependency`dulwich` and pushing the files. This might be able to be done but would be much more complicated (in my opinion).