### PR TITLE
Sanitize ascii control characters (they're not allowed on Windows)

### DIFF
--- a/crowd_anki/utils/filesystem/name_sanitizer.py
+++ b/crowd_anki/utils/filesystem/name_sanitizer.py
@@ -1,6 +1,7 @@
 from functional import seq
 
-invalid_filename_chars = set(":*?\"<>|/\\ \n")
+ascii_control_chars = ''.join([chr(x) for x in range(0,32)])
+invalid_filename_chars = set(":*?\"<>|/\\ \n" + ascii_control_chars)
 
 
 def sanitize_anki_deck_name(name: str, replace_char='_'):


### PR DESCRIPTION
Fix #147.

Unlike Linux, Windows doesn't allow ASCII control characters (codepoint < 32) in filenames.  See:

https://stackoverflow.com/a/31976060/6598435

https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions

For consistency, we should remove them always.

This might be a moot issue, since in recent versions of Anki (2.1.43 tested) it seems that all such control characters (including \n) are already filtered out from deck names, but I don't think it hurts.

\n will be double-counted, but I think it's best to keep it explicitly for readability (and since we're using a set, duplication doesn't matter).

The `join` takes just 5 μs, so I think replacing it with the "computed" string is not worth the drop in readability.