### PR TITLE
Add test for repeated "import" (clone and pull) from git

### DIFF
--- a/test/github/github_importer_spec.py
+++ b/test/github/github_importer_spec.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from unittest.mock import MagicMock, patch
+from mamba import describe, it, context
+from expects import expect, equal
+
+from crowd_anki.github.github_importer import GitImporter
+
+TEST_GIT_REPO = "https://github.com/Stvad/Software_Engineering__git"
+CLONE_REPETITIONS = 3
+
+temp_dir = TemporaryDirectory()
+repo_local_path = Path(temp_dir.name)
+
+GitImporter.get_repo_local_path = lambda self, x: repo_local_path
+
+with describe(GitImporter) as self:
+    with context("user is trying to import a deck from a git repo multiple times"):
+        # See #138!
+        with it("should clone the git repo without crashing"):
+            self.collection_mock = MagicMock()
+            self.subject = GitImporter(self.collection_mock)
+            with patch("crowd_anki.github.github_importer.AnkiJsonImporter") as mock_json_importer:
+                for _ in range(0, CLONE_REPETITIONS):
+                    self.subject.clone_repository_and_import(TEST_GIT_REPO)
+                expect(mock_json_importer.import_deck_from_path.call_count).to(equal(3))
+
+            # Note: the import itself isn't being tested (we're not,
+            # yet (as of 2021-11) testing import itself in any
+            # situation)!
+
+temp_dir.cleanup()


### PR DESCRIPTION
Diagnose #138 which occurred on Windows.  (A lock for the git pack file is often held by a previous clone/pull and not released, so the next pull fails (`PermissionError`).)

Without the fix from #139, the test indeed fails (as expected/desired)! (See https://github.com/aplaice/CrowdAnki/pull/2.)

With the fix from #139, the test indeed succeeds (as expected/desired)! (See https://github.com/aplaice/CrowdAnki/pull/3.)

<hr/>

I'll leave all these PRs open for several days in case there are comments and if not, carefully merge them in the right order (fixes to tests, tests, GitHub actions?, fixes). 

<hr/>

Edit: I added GitHub actions before the new test, to double-check that the new test fails on Windows, in the final configuration, not just with my haphazard set of commits, in the fork.

I'm not _too_ happy with the precise implementation of this test, so I'll leave it for a couple of days, in case I can think of some improvements.