### PR TITLE
Annotate/clean up compatibility shims

### DIFF
--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -104,6 +104,8 @@ class Deck(JsonSerializableAnkiDict):
         media = set()
         for note in self.notes:
             anki_object = note.anki_object
+            # TODO Remove compatibility shims for Anki 2.1.46 and
+            # lower.
             join_fields = anki_object.joined_fields if hasattr(anki_object, 'joined_fields') else anki_object.joinedFields
             for media_file in self.collection.media.filesInStr(anki_object.mid, join_fields()):
                 media.add(media_file)

--- a/crowd_anki/representation/deck_config.py
+++ b/crowd_anki/representation/deck_config.py
@@ -10,6 +10,7 @@ class DeckConfig(JsonSerializableAnkiDict):
     @classmethod
     def from_collection(cls, collection, deck_config_id):
         decks = collection.decks
+        # TODO Remove compatibility shims for Anki 2.1.46 and lower.
         get_conf = decks.get_config if hasattr(decks, 'get_config') else decks.getConf
         anki_dict = get_conf(deck_config_id)
         deck_config = DeckConfig(anki_dict)

--- a/crowd_anki/representation/deck_initializer.py
+++ b/crowd_anki/representation/deck_initializer.py
@@ -8,6 +8,7 @@ from ..anki.adapters.note_model_file_provider import NoteModelFileProvider
 
 def from_collection(collection, name, deck_metadata=None, is_child=False) -> Deck:
     decks = collection.decks
+    # TODO Remove compatibility shims for Anki 2.1.46 and lower.
     by_name = decks.by_name if hasattr(decks, 'by_name') else decks.byName
     anki_dict = by_name(name)
 

--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -54,6 +54,9 @@ class Note(JsonSerializableAnkiObject):
         return self.anki_object.guid if self.anki_object else self.anki_object_dict.get("guid")
 
     def note_type(self):
+        # TODO Remove compatibility shims for Anki 2.1.46 and lower.
+        # (Remove this method altogether — see old version in git
+        # history.)
         return self.anki_object.note_type() if hasattr(self.anki_object, 'note_type') else self.anki_object.model()
 
     def handle_model_update(self, collection, model_map_cache):

--- a/crowd_anki/representation/note_model.py
+++ b/crowd_anki/representation/note_model.py
@@ -1,16 +1,10 @@
 from collections import namedtuple
 
 from anki import Collection
-from anki import version as anki_version
 from .json_serializable import JsonSerializableAnkiDict
 from ..anki.overrides.change_model_dialog import ChangeModelDialog
 from ..utils import utils
 from ..utils.uuid import UuidFetcher
-
-anki_version = anki_version.split(".")
-anki_major = int(anki_version[0])
-anki_minor = int(anki_version[1])
-anki_point = int(anki_version[2])
 
 
 class NoteModel(JsonSerializableAnkiDict):
@@ -54,9 +48,6 @@ class NoteModel(JsonSerializableAnkiDict):
             collection.models.add(self.anki_dict)
         else:
             collection.models.update(self.anki_dict)
-
-        if anki_major < 3 and anki_minor < 2 and anki_point < 48:
-            collection.models.flush()
 
         if not new_model:
             self.update_cards(collection, note_model_dict)


### PR DESCRIPTION
1. Annotate compatibility hacks (for removal, soon)

   They (or something approximately like them) is needed to keep compatibility with 2.1.40, but they add some complexity, so we should be able to get rid of them (or move them elsewhere) (e.g. after a new release).


2. Remove collection.models.flush() altogether

   It has been "legacy" since 2.1.28 (commit on 2020-05-12 — see [`flush` in `pylib/anki/models.py` in `f637ac957d206ead619d54d6cf86eb8958ea508c`](https://github.com/ankitects/anki/commit/f637ac957d206ead619d54d6cf86eb8958ea508c#diff-3b9e2c34f22da648e023ec78cacc60af8ced7711fedbc13add9d9d09a67d618eR154-R156)).

   We only have compatibility with 2.1.40 anyway, so losing another 2.1.26 feature isn't an issue.