### PR TITLE
Allow disambiguating duplicated note model UUIDs in collection

### DIFF
--- a/crowd_anki/export/anki_exporter_wrapper.py
+++ b/crowd_anki/export/anki_exporter_wrapper.py
@@ -5,6 +5,7 @@ from ..anki.adapters.anki_deck import AnkiDeck
 from ..config.config_settings import ConfigSettings
 from ..utils import constants
 from ..utils.notifier import AnkiModalNotifier, Notifier
+from ..utils.disambiguate_uuids import disambiguate_note_model_uuids
 
 EXPORT_FAILED_TITLE = "Export failed"
 
@@ -44,6 +45,10 @@ class AnkiJsonExporterWrapper:
         if deck.is_dynamic:
             self.notifier.warning(EXPORT_FAILED_TITLE, "CrowdAnki does not support export for dynamic decks.")
             return
+
+        # Clean up duplicate note models. See
+        # https://github.com/Stvad/CrowdAnki/wiki/Workarounds-%E2%80%94-Duplicate-note-model-uuids.
+        disambiguate_note_model_uuids(self.collection)
 
         # .parent because we receive name with random numbers at the end (hacking around internals of Anki) :(
         export_path = Path(directory_path).parent

--- a/crowd_anki/history/archiver_vendor.py
+++ b/crowd_anki/history/archiver_vendor.py
@@ -10,6 +10,7 @@ from ..anki.ui.utils import progress_indicator
 from ..config.config_settings import ConfigSettings
 from ..export.anki_exporter import AnkiJsonExporter
 from ..utils.notifier import Notifier, AnkiTooltipNotifier
+from ..utils.disambiguate_uuids import disambiguate_note_model_uuids
 
 
 @dataclass
@@ -41,6 +42,10 @@ class ArchiverVendor:
             self.do_snapshot('CrowdAnki: Snapshot on sync')
 
     def do_snapshot(self, reason):
+        # Clean up duplicate note models. See
+        # https://github.com/Stvad/CrowdAnki/wiki/Workarounds-%E2%80%94-Duplicate-note-model-uuids.
+        disambiguate_note_model_uuids(self.window.col)
+
         with progress_indicator(self.window, 'Taking CrowdAnki snapshot of all decks'):
             self.all_deck_archiver().archive(overrides=self.overrides(),
                                              reason=reason)

--- a/crowd_anki/utils/disambiguate_uuids.py
+++ b/crowd_anki/utils/disambiguate_uuids.py
@@ -1,0 +1,54 @@
+from uuid import uuid1
+
+from .notifier import AnkiModalNotifier
+
+def disambiguate_note_model_uuids(collection):
+    """Disambiguate duplicate note model UUIDs.
+
+    In CrowdAnki ≤ 0.9, cloning a note model with an already assigned
+    crowdanki_uuid resulted in the clone inheriting the "original's"
+    crowdanki_uuid.
+
+    This has been fixed (#136), but:
+
+    1. Users will still have duplicate UUIDs from before the upgrade.
+
+    2. Users who create note models on platforms other than Anki with
+    CrowdAnki installed — for instance on mobile — will still have the
+    old issue, since cloning note models on those platforms will again
+    clone UUIDs.
+
+    """
+    notifier = AnkiModalNotifier()
+    uuids = []
+    full_message = ""
+    for model in filter(lambda model: "crowdanki_uuid" in model,
+                        sorted(collection.models.all(), key=lambda m: m["id"])):
+        # We're sorting by note model id, because it almost always
+        # (see the discussion in the PR for this addition) corresponds
+        # to the time of creation of the note model, in milliseconds
+        # since the epoch, so the copies will almost always have
+        # larger ids than the originals, so we'll hopefully be
+        # changing the UUIDs of the copies, not the originals.
+        crowdanki_uuid = model["crowdanki_uuid"]
+        if crowdanki_uuid in uuids:
+            new_crowdanki_uuid = str(uuid1())
+            model["crowdanki_uuid"] = new_crowdanki_uuid
+            collection.models.save(model)
+            message = (f"Replacing duplicate UUID ({crowdanki_uuid}) for note model "
+                       f"“{model['name']}” with new UUID ({new_crowdanki_uuid})!\n")
+            # Printing in the unlikely case there's a crash later in
+            # the loop.
+            print(message)
+            full_message += message
+        else:
+            uuids.append(crowdanki_uuid)
+
+    if full_message:
+        full_message += (
+            "\nFor details, please see "
+            "https://github.com/Stvad/CrowdAnki/wiki/Workarounds-—-Duplicate-note-model-uuids .\n\n"
+            "The replacement should be a one-off occurrence.  "
+            "If this message appears frequently, please open an issue!"
+        )
+        notifier.info("UUIDs disambiguated", full_message)

--- a/crowd_anki/utils/disambiguate_uuids.py
+++ b/crowd_anki/utils/disambiguate_uuids.py
@@ -2,7 +2,7 @@ from uuid import uuid1
 
 from .notifier import AnkiModalNotifier
 
-def disambiguate_note_model_uuids(collection):
+def disambiguate_note_model_uuids(collection, notifier=None) -> None:
     """Disambiguate duplicate note model UUIDs.
 
     In CrowdAnki ≤ 0.9, cloning a note model with an already assigned
@@ -19,7 +19,8 @@ def disambiguate_note_model_uuids(collection):
     clone UUIDs.
 
     """
-    notifier = AnkiModalNotifier()
+    if notifier is None:
+        notifier = AnkiModalNotifier()
     uuids = []
     full_message = ""
     for model in filter(lambda model: "crowdanki_uuid" in model,

--- a/test/utils/disambiguate_uuids.py
+++ b/test/utils/disambiguate_uuids.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+from copy import deepcopy
+
+from expects import expect, equal
+from mamba import description, it
+
+from crowd_anki.utils.disambiguate_uuids import disambiguate_note_model_uuids
+
+MODELS_WITH_DUPLICATES = [
+    {
+        "id": 1,
+        "name": "Basic",
+        "crowdanki_uuid": "79141f05-73b8-4836-a97f-438ec28bd8a5",
+    },
+    {
+        "id": 2,
+        "name": "Basic copy",
+        "crowdanki_uuid": "79141f05-73b8-4836-a97f-438ec28bd8a5",
+    }
+]
+
+MODELS_WITHOUT_DUPLICATES = [
+    {
+        "id": 1,
+        "name": "Basic",
+        "crowdanki_uuid": "79141f05-73b8-4836-a97f-438ec28bd8a5",
+    },
+    {
+        "id": 2,
+        "name": "Basic copy",
+        "crowdanki_uuid": "6a69bc9d-de6d-42b3-9ba3-9f6e9cc09179",
+    }
+]
+
+@dataclass
+class Models:
+    """Mock Anki's models, without initialising Anki's backend."""
+    models: dict
+
+Models.all = lambda self: self.models
+Models.save = MagicMock()
+
+with description("disambiguate_note_model_uuids"):
+    with it("should disambiguate duplicated note model uuids"):
+        collection = MagicMock()
+        notifier = MagicMock()
+        collection.models = Models(deepcopy(MODELS_WITH_DUPLICATES))
+        disambiguate_note_model_uuids(collection, notifier)
+
+        expect(collection.models.all()).not_to(equal(MODELS_WITH_DUPLICATES))
+        expect(collection.models.all()[0]).to(equal(MODELS_WITH_DUPLICATES[0]))
+
+    with it("should keep note models without duplicates unchanged uuids"):
+        collection = MagicMock()
+        notifier = MagicMock()
+        collection.models = Models(deepcopy(MODELS_WITHOUT_DUPLICATES))
+        disambiguate_note_model_uuids(collection, notifier)
+
+        expect(collection.models.all()).to(equal(MODELS_WITHOUT_DUPLICATES))


### PR DESCRIPTION
The issue of note model UUIDs being cloned along with the note models themselves has been fixed (#136).  However, many users' collections will already contain such duplicated note model UUIDs.  Also, if a user clones a note type on another platform, then the UUID will still be duplicated.

The disambiguation is run before export and snapshot, since that's when it's most needed to avoid broken `deck.json`s.

In the long, run we could perhaps switch to running the code only after syncing (since our "attack surface" would be cloning of note models on other platforms).

Running `disambiguate_note_model_uuids` takes 10 ms on a collection with 20 note types (without duplicates), which is IMO an acceptable overhead.

The file `disambiguate_uuids.py` could also contain the (far lower priority) disambiguation of deck config UUIDs (see #135).

I've chosen to set a new UUID immediately (rather than just removing it and having it be regenerated when it's needed (possibly during the export/snapshot immediately after), which would work just as well) because IMO it's more comprehensible to the end-user — the new and old UUIDs are both listed together and they can inspect their `deck.json`s.

<hr/>

The key question is how to determine which note model is "the original".  I think that using the note type id (`notetypes.id`) is a sufficiently good proxy.

## Details

When creating a new note model in Anki (e.g. via cloning), the id of the new note type is [the time in milliseconds since the epoch](https://github.com/ankitects/anki/blob/fcb21ceed51a42b2beaaec1fe71e4377ea1c1033/rslib/src/storage/notetype/mod.rs#L214), unless that id is already taken, in which case it's [that time + 1](https://github.com/ankitects/anki/blob/main/rslib/src/storage/notetype/add_notetype.sql#L9).  In either case, the id of any newer note model will be greater than the id of any older note models.  AFAICT AnkiDroid [uses the same rust backend](https://github.com/ankidroid/Anki-Android/blob/32c3c10af8d31892901f5fe9ec33ab947143e39b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/ModelsBackend.kt#L92), so its behaviour should be the same.  AnkiMobile generally reuses Anki's code, so it should also behave the same way.

(I haven't dug into the old Anki python version of the code, but from what I've read online, it's "always" been the case that the notetype should be the unix time (in `ms`).  Looking at some of my own old (built-in) note types, their `id`s correspond to the time when I started using Anki, further supporting the hypothesis.)

AFAICT based on skimming the code and testing, updating an existing note type (even changing the number of fields and the number of cards) does not change its id (which feels logical).

People might also generate model ids outside Anki, for instance using [genanki](https://github.com/kerrickstaley/genanki/).  Genanki's [recommendation](https://github.com/kerrickstaley/genanki/blob/master/README.md) is to generate a random integer between `2^31` and `2^32`.  Since all unix times (in ms) from this millenium are greater than `2^32`, then assuming that people followed genanki's recommendations, then the ids of any genanki note models will be smaller than the ids of any note models created from these note models (by cloning) in Anki, so again ordering of id maps onto newness, well.


There are some special cases, [for instance when upgrading a collection which had a note model id of 0](https://github.com/ankitects/anki/blob/main/rslib/src/storage/notetype/mod.rs#L313), but here again the generated id is less than `2^32`, so it will also be smaller than any time-based id.

## Summary

Overall, while it's in principle possible that the cloned copy of a note model will have a smaller id than the original note model, it seems highly unlikely.