### PR TITLE
Adapt to 2.1.50+ backup mechanism

### DIFF
--- a/crowd_anki/anki/overrides/exporting.py
+++ b/crowd_anki/anki/overrides/exporting.py
@@ -23,7 +23,7 @@ def get_save_file(parent, title, dir_description, key, ext, fname=None):
         directory = str(QFileDialog.getExistingDirectory(caption="Select Export Directory",
                                                          directory=fname))
         if directory:
-            return os.path.join(directory, str(anki.utils.intTime()))
+            return os.path.join(directory, str(anki.utils.int_time()))
         return None
 
     return aqt.utils.getSaveFile_old(parent, title, dir_description, key, ext, fname)

--- a/crowd_anki/importer/anki_importer.py
+++ b/crowd_anki/importer/anki_importer.py
@@ -33,9 +33,7 @@ class AnkiJsonImporter:
             return False
 
         if aqt.mw:
-            aqt.mw.col.close(downgrade=False)
-            aqt.mw.backup()
-            aqt.mw.col.reopen(after_full_sync=False)
+            aqt.mw.create_backup_now()
         try:
             deck = deck_initializer.from_json(deck_json)
             deck.save_to_collection(self.collection, import_config=import_config)

--- a/crowd_anki/representation/deck.py
+++ b/crowd_anki/representation/deck.py
@@ -107,7 +107,7 @@ class Deck(JsonSerializableAnkiDict):
             # TODO Remove compatibility shims for Anki 2.1.46 and
             # lower.
             join_fields = anki_object.joined_fields if hasattr(anki_object, 'joined_fields') else anki_object.joinedFields
-            for media_file in self.collection.media.filesInStr(anki_object.mid, join_fields()):
+            for media_file in self.collection.media.files_in_str(anki_object.mid, join_fields()):
                 media.add(media_file)
 
         if include_children:

--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -122,7 +122,7 @@ class Note(JsonSerializableAnkiObject):
 
         self.anki_object.__dict__.update(self.anki_object_dict)
         self.anki_object.mid = note_model.anki_dict["id"]
-        self.anki_object.mod = anki.utils.intTime()
+        self.anki_object.mod = anki.utils.int_time()
 
         if new_note:
             collection.add_note(self.anki_object, deck.anki_dict["id"])


### PR DESCRIPTION
Fix #166.

It's no longer necessary for the collection to be closed before a backup, and AFAICT a closed collection can't even be backed up.

See PR 1728 in Anki itself.  (Not linking directly to avoid spam for DAE etc.)

This breaks compatibility with 2.1.49-.

Also: silence most verbose deprecation warnings (in 2.1.50+)

I've left the Qt warnings alone for now, since the behaviour varies between Qt5 and Qt6.

<hr/>

AFAICT importing, exporting and snapshotting all work in 2.1.50 and 2.1.52 both with Qt5 and Qt6 (using the default Qt5 compatibility shims).