### PR TITLE
Update to latest pipenv and fix our tests

### DIFF
--- a/.github/workflows/mamba.yml
+++ b/.github/workflows/mamba.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Write dulwich version to requirements.txt
       shell: bash
       run: |
-        pipenv lock -r | sed -nE 's/(^dulwich==.+$)/\1 --global-option=--pure/p' > requirements.txt
+        pipenv requirements | sed -nE 's/(^dulwich==.+$)/\1 --global-option=--pure/p' > requirements.txt
 
     - name: Install pure dulwich from requirements.txt
       run: |

--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-pipenv run pip install --upgrade --no-binary :all: -r <(pipenv lock -r | sed -E "s/(^dulwich==.+$)/\1 --global-option=--pure/")  --target crowd_anki/dist
+pipenv run pip install --upgrade --no-binary :all: -r <(pipenv requirements | sed -E "s/(^dulwich==.+$)/\1 --global-option=--pure/")  --target crowd_anki/dist


### PR DESCRIPTION
`pipenv lock -r` has been replaced by `pipenv requirements`.

I _think_ that the API is now slightly different, with the first line now describing the choice of index.  I don't think that this is an issue.