### PR TITLE
Avoid mocking Anki modules globally

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -304,6 +304,14 @@
             "markers": "sys_platform != 'darwin' and sys_platform != 'win32'",
             "version": "==1.5.0"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a",
+                "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.0.1"
+        },
         "expects": {
             "hashes": [
                 "sha256:419902ccafe81b7e9559eeb6b7a07ef9d5c5604eddb93000f0642b3b2d594f4c"
@@ -496,6 +504,14 @@
             "markers": "platform_machine == 'x86_64'",
             "version": "==3.5.3"
         },
+        "pkgutil-resolve-name": {
+            "hashes": [
+                "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174",
+                "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==1.3.10"
+        },
         "protobuf": {
             "hashes": [
                 "sha256:0f237c1e84e46747397a3e8173edb3116e81163b2878fc944a5193b05876eaee",
@@ -526,14 +542,14 @@
         },
         "pyqt5": {
             "hashes": [
-                "sha256:14be35c0c1bcc804791a096d2ef9950f12c6fd34dd11dbe61b8c769fefcdf98c",
-                "sha256:3605d34ba6291b9194c46035e228d6d01f39d120cf5ecc70301c11e7900fed21",
-                "sha256:5bac0fab1e9891d73400c2470a9cb810e6bdbc7027a84ae4d3ec83436f1109ec",
-                "sha256:c6f75488ffd5365a65893bc64ea82a6957db126fbfe33654bcd43ae1c30c52f9",
-                "sha256:e05c86b8c4f02d62a5b355d426fd8d063781dd44c6a3f916640a5beb40efe60a"
+                "sha256:08694f0a4c7d4f3d36b2311b1920e6283240ad3b7c09b515e08262e195dcdf37",
+                "sha256:1a793748c60d5aff3850b7abf84d47c1d41edb11231b7d7c16bef602c36be643",
+                "sha256:232fe5b135a095cbd024cf341d928fc672c963f88e6a52b0c605be8177c2fdb5",
+                "sha256:755121a52b3a08cb07275c10ebb96576d36e320e572591db16cfdbc558101594",
+                "sha256:e319c9d8639e0729235c1b09c99afdadad96fa3dbd8392ab561b5ab5946ee6ef"
             ],
             "index": "pypi",
-            "version": "==5.15.0"
+            "version": "==5.15.7"
         },
         "pyqt5-qt5": {
             "hashes": [
@@ -546,40 +562,41 @@
         },
         "pyqt5-sip": {
             "hashes": [
-                "sha256:055581c6fed44ba4302b70eeb82e979ff70400037358908f251cd85cbb3dbd93",
-                "sha256:0fc9aefacf502696710b36cdc9fa2a61487f55ee883dbcf2c2a6477e261546f7",
-                "sha256:42274a501ab4806d2c31659170db14c282b8313d2255458064666d9e70d96206",
-                "sha256:4347bd81d30c8e3181e553b3734f91658cfbdd8f1a19f254777f906870974e6d",
-                "sha256:485972daff2fb0311013f471998f8ec8262ea381bded244f9d14edaad5f54271",
-                "sha256:4f8e05fe01d54275877c59018d8e82dcdd0bc5696053a8b830eecea3ce806121",
-                "sha256:69a3ad4259172e2b1aa9060de211efac39ddd734a517b1924d9c6c0cc4f55f96",
-                "sha256:6a8701892a01a5a2a4720872361197cc80fdd5f49c8482d488ddf38c9c84f055",
-                "sha256:6d5bca2fc222d58e8093ee8a81a6e3437067bb22bc3f86d06ec8be721e15e90a",
-                "sha256:83c3220b1ca36eb8623ba2eb3766637b19eb0ce9f42336ad8253656d32750c0a",
-                "sha256:a25b9843c7da6a1608f310879c38e6434331aab1dc2fe6cb65c14f1ecf33780e",
-                "sha256:ac57d796c78117eb39edd1d1d1aea90354651efac9d3590aac67fa4983f99f1f",
-                "sha256:b09f4cd36a4831229fb77c424d89635fa937d97765ec90685e2f257e56a2685a",
-                "sha256:c446971c360a0a1030282a69375a08c78e8a61d568bfd6dab3dcc5cf8817f644",
-                "sha256:c5216403d4d8d857ec4a61f631d3945e44fa248aa2415e9ee9369ab7c8a4d0c7",
-                "sha256:d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32",
-                "sha256:d59af63120d1475b2bf94fe8062610720a9be1e8940ea146c7f42bb449d49067",
-                "sha256:d85002238b5180bce4b245c13d6face848faa1a7a9e5c6e292025004f2fd619a",
-                "sha256:d8b2bdff7bbf45bc975c113a03b14fd669dc0c73e1327f02706666a7dd51a197",
-                "sha256:dd05c768c2b55ffe56a9d49ce6cc77cdf3d53dbfad935258a9e347cbfd9a5850",
-                "sha256:fc43f2d7c438517ee33e929e8ae77132749c15909afab6aeece5fcf4147ffdb5"
+                "sha256:0f77655c62ec91d47c2c99143f248624d44dd2d8a12d016e7c020508ad418aca",
+                "sha256:205f3e1b3eea3597d8e878936c1a06e04bd23a59e8b179ee806465d72eea3071",
+                "sha256:3126c84568ab341c12e46ded2230f62a9a78752a70fdab13713f89a71cd44f73",
+                "sha256:4031547dfb679be309094bfa79254f5badc5ddbe66b9ad38e319d84a7d612443",
+                "sha256:42320e7a94b1085ed85d49794ed4ccfe86f1cae80b44a894db908a8aba2bc60e",
+                "sha256:43dfe6dd409e713edeb67019b85419a7a0dc9923bfc451d6cf3778471c122532",
+                "sha256:4e5c1559311515291ea0ab0635529f14536954e3b973a7c7890ab7e4de1c2c23",
+                "sha256:51e377789d59196213eddf458e6927f33ba9d217b614d17d20df16c9a8b2c41c",
+                "sha256:686071be054e5be6ca5aaaef7960931d4ba917277e839e2e978c7cbe3f43bb6e",
+                "sha256:9356260d4feb60dbac0ab66f8a791a0d2cda1bf98c9dec8e575904a045fbf7c5",
+                "sha256:9bca450c5306890cb002fe36bbca18f979dd9e5b810b766dce8e3ce5e66ba795",
+                "sha256:ad21ca0ee8cae2a41b61fc04949dccfab6fe008749627d94e8c7078cb7a73af1",
+                "sha256:afa4ffffc54e306669bf2b66ea37abbc56c5cdda4f3f474d20324e3634302b12",
+                "sha256:b4710fd85b57edef716cc55fae45bfd5bfac6fc7ba91036f1dcc3f331ca0eb39",
+                "sha256:b69a1911f768b489846335e31e49eb34795c6b5a038ca24d894d751e3b0b44da",
+                "sha256:bd733667098cac70e89279d9c239106d543fb480def62a44e6366ccb8f68510b",
+                "sha256:d12b81c3a08abf7657a2ebc7d3649852a1f327eb2146ebadf45930486d32e920",
+                "sha256:ec1d8ce50be76c5c1d1c86c6dc0ccacc2446172dde98b663a17871f532f9bd44",
+                "sha256:ec5e9ef78852e1f96f86d7e15c9215878422b83dde36d44f1539a3062942f19c",
+                "sha256:f1f9e312ff8284d6dfebc5366f6f7d103f84eec23a4da0be0482403933e68660",
+                "sha256:f6b72035da4e8fecbb0bc4a972e30a5674a9ad5608dbddaa517e983782dbf3bf"
             ],
-            "version": "==12.9.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==12.11.0"
         },
         "pyqtwebengine": {
             "hashes": [
-                "sha256:30cebf455406990d5a0b859eac261ba6b45c32ce18956271733e0e96dbdca9b7",
-                "sha256:5c77f71d88d871bc7400c68ef6433fadc5bd57b86d1a9c4d8094cea42f3607f1",
-                "sha256:782aeee6bc8699bc029fe5c169a045c2bc9533d781cf3f5e9fb424b85a204e68",
-                "sha256:ab47608dccf2b5e4b950d5a3cc704b17711af035024d07a9b71ad29fc103b941",
-                "sha256:b827ad7ba0a65d5cd176797478f0ec8f599df6746b06c548649ff5674482a022"
+                "sha256:67110bc9d5b7e633dcc242b8228cc54b1532abc039fdf534b383ac40a60b7ba3",
+                "sha256:8c2fce2458e7b781d2cc3070b336f67d39a717c5eef2f823cae501d5d9f200de",
+                "sha256:a90c945606683a53c9b264a7509943fd835d50366d535c22ddde952f23d35748",
+                "sha256:ae241ef2a61c782939c58b52c2aea53ad99b30f3934c8358d5e0a6ebb3fd0721",
+                "sha256:dbd1a768877040050d3159270f5ab95758af4954c4cb4e54195bd3cad519d5b6"
             ],
             "index": "pypi",
-            "version": "==5.15.5"
+            "version": "==5.15.6"
         },
         "pyqtwebengine-qt5": {
             "hashes": [

--- a/test/config/config_settings_spec.py
+++ b/test/config/config_settings_spec.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock
 from expects import expect, contain
 from mamba import describe, it, context
 
-from test_utils.anki import mock_anki_modules
+from test_utils.anki import MockAnkiModules
 
-mock_anki_modules()
+mock_anki_modules = MockAnkiModules()
+
 from aqt import mw
 
 from crowd_anki.config.config_settings import ConfigSettings, NoteSortingMethods
@@ -94,3 +95,5 @@ with describe(ConfigSettings) as self:
 
             expect(config._config.items()).to(contain(*list(new_settings.items())))
             addon_manager_mock.writeConfig.assert_called_once()
+
+mock_anki_modules.unmock()

--- a/test/export/anki_exporter_wrapper_spec.py
+++ b/test/export/anki_exporter_wrapper_spec.py
@@ -2,6 +2,10 @@ from unittest.mock import MagicMock
 
 from mamba import describe, it, context
 
+from test_utils.anki import MockAnkiModules
+
+mock_anki_modules = MockAnkiModules(["win32file", "win32pipe", "pywintypes", "winerror"]) # Anki on Windows uses pywin32
+
 from crowd_anki.export.anki_exporter_wrapper import AnkiJsonExporterWrapper
 
 DUMMY_EXPORT_DIRECTORY = "/tmp"
@@ -23,3 +27,5 @@ with describe(AnkiJsonExporterWrapper) as self:
 
             notifier_mock.warning.assert_called_once()
             exporter_mock.export_to_directory.assert_not_called()
+
+mock_anki_modules.unmock()

--- a/test_utils/anki/__init__.py
+++ b/test_utils/anki/__init__.py
@@ -2,15 +2,26 @@ import sys
 
 from unittest.mock import MagicMock
 
-
-def mock_anki_modules():
+class MockAnkiModules:
     """
     I'd like to get rid of the situation when this is required, but for now this helps with the situation that
     anki modules are not available during test runtime.
     """
-
     modules_list = ['anki', 'anki.hooks', 'anki.exporting', 'anki.decks', 'anki.utils', 'anki.cards', 'anki.models',
-                    'anki.notes', 'aqt''', 'aqt.qt', 'aqt.exporting', 'aqt.utils']
+                    'anki.notes', 'aqt', 'aqt.qt', 'aqt.exporting', 'aqt.utils']
 
-    for module in modules_list:
-        sys.modules[module] = MagicMock()
+    def __init__(self):
+        self.shadowed_modules = {}
+
+        for module in self.modules_list:
+            self.shadowed_modules[module] = sys.modules.get(module)
+            sys.modules[module] = MagicMock()
+
+    def unmock(self):
+        for module in self.modules_list:
+            shadowed_module = self.shadowed_modules[module]
+            if shadowed_module is not None:
+                sys.modules[module] = shadowed_module
+            else:
+                if module in sys.modules:
+                    del sys.modules[module]

--- a/test_utils/anki/__init__.py
+++ b/test_utils/anki/__init__.py
@@ -1,3 +1,5 @@
+from typing import List
+from typing import Optional
 import sys
 
 from unittest.mock import MagicMock
@@ -7,21 +9,23 @@ class MockAnkiModules:
     I'd like to get rid of the situation when this is required, but for now this helps with the situation that
     anki modules are not available during test runtime.
     """
-    modules_list = ['anki', 'anki.hooks', 'anki.exporting', 'anki.decks', 'anki.utils', 'anki.cards', 'anki.models',
-                    'anki.notes', 'aqt', 'aqt.qt', 'aqt.exporting', 'aqt.utils']
+    module_names_list = ['anki', 'anki.hooks', 'anki.exporting', 'anki.decks', 'anki.utils', 'anki.cards', 'anki.models',
+                         'anki.notes', 'aqt', 'aqt.qt', 'aqt.exporting', 'aqt.utils']
 
-    def __init__(self):
+    def __init__(self, module_names_list: Optional[List[str]] = None):
+        if module_names_list is None:
+            module_names_list = self.module_names_list
+
         self.shadowed_modules = {}
 
-        for module in self.modules_list:
-            self.shadowed_modules[module] = sys.modules.get(module)
-            sys.modules[module] = MagicMock()
+        for module_name in module_names_list:
+            self.shadowed_modules[module_name] = sys.modules.get(module_name)
+            sys.modules[module_name] = MagicMock()
 
     def unmock(self):
-        for module in self.modules_list:
-            shadowed_module = self.shadowed_modules[module]
-            if shadowed_module is not None:
-                sys.modules[module] = shadowed_module
+        for module_name, module in self.shadowed_modules.items():
+            if module is not None:
+                sys.modules[module_name] = module
             else:
-                if module in sys.modules:
-                    del sys.modules[module]
+                if module_name in sys.modules:
+                    del sys.modules[module_name]


### PR DESCRIPTION
Ideally, we'd stop mocking them _at all_ but this is a good first step, as it's annoying and surprising (with the current/previous _global_ mocking, the test is/was run differently depending on whether it was run individually or as part of a batch).

Fix #145.

(The solution could probably be neater (e.g. we could use a context manager), but I don't think it's worth it.)

(The reproduction in #145 no longer works, as-is, as the tests don't crash even without mocking. (Edit: famous last words :D (though AFAICT the issue is PyQt5.QtWebEngineWidgets not wanting to be imported on Windows rather than a bug in our code).)

<hr/>

The issue is now `pywin32` which _might_ be tricky getting into the pipenv (even if we wanted to...). (Mocking it might be a simpler approach. :/)