### PR TITLE
Add manifest.json

### DIFF
--- a/crowd_anki/manifest.json
+++ b/crowd_anki/manifest.json
@@ -1,0 +1,10 @@
+{
+  "package": "crowd-anki",
+  "name": "CrowdAnki",
+  "mod": 1675154545,
+  "conflicts": [],
+  "min_point_version": 50,
+  "max_point_version": 57,
+  "human_version": "v0.9.3",
+  "homepage": "https://github.com/Stvad/CrowdAnki/"
+}

--- a/crowd_anki/manifest.json
+++ b/crowd_anki/manifest.json
@@ -1,10 +1,7 @@
 {
   "package": "crowd-anki",
   "name": "CrowdAnki",
-  "mod": 1675154545,
   "conflicts": [],
   "min_point_version": 50,
-  "max_point_version": 57,
-  "human_version": "v0.9.3",
   "homepage": "https://github.com/Stvad/CrowdAnki/"
 }


### PR DESCRIPTION
I do not think that keeping manifest.json in the source tree has any disadvantages (e.g. for manual install or for uploading to AnkiWeb).  Having a manifest.json allows users to install the zipped add-on via the new-ish "sharing outside ankiweb" install process[0].

Not all the fields are specified in the docs, but they can be sleuthed by inspecting Anki's source code[1].

It _might_ make sense for `mod` and `human_version`, to be updated automatically, when releasing, or we could just drop them.

If we ever have beta builds, the conflicts field could allow the release builds to conflict with the beta builds (and vice-versa), to allow users a way to quickly and easily switch.

A positive max_point_version does not indicate maximum 2.1.x compatible Anki version, but the highest version tested.

[0] https://addon-docs.ankiweb.net/sharing.html#sharing-outside-ankiweb

[1] https://github.com/ankitects/anki/blob/c32f14f7cbc9461e35548afa5b42c5424606008f/qt/aqt/addons.py#L186

<hr/>

For the moment I manually added a manifest.json to the latest release.