### PR TITLE
Allow sorting subdecks according to sorting method

### DIFF
--- a/crowd_anki/anki/overrides/decks.py
+++ b/crowd_anki/anki/overrides/decks.py
@@ -3,6 +3,16 @@ from anki.decks import DeckManager
 
 
 def get_card_ids(self, did, children=False, include_from_dynamic=False):
+    """Get ids of cards in deck with id `did`.
+
+    If include_from_dynamic=True includes cards that are currently in
+    a filtered deck, but which originally come from the specified
+    deck.
+
+    If children=True include cards from children, _recursively_.
+    (Anki's DeckManager.children(did) is recursive.)
+
+    """
     deck_ids = [did] + ([deck_id for _, deck_id in self.children(did)] if children else [])
 
     request = "select id from cards where did in {}" + ("or odid in {}" if include_from_dynamic else "")

--- a/crowd_anki/export/anki_exporter.py
+++ b/crowd_anki/export/anki_exporter.py
@@ -36,7 +36,7 @@ class AnkiJsonExporter(DeckExporter):
 
         deck = deck_initializer.from_collection(self.collection, deck.name)
 
-        deck.notes = self.note_sorter.sort_notes(deck.notes)
+        self.note_sorter.sort_deck(deck)
 
         self.last_exported_count = deck.get_note_count()
 

--- a/crowd_anki/export/note_sorter.py
+++ b/crowd_anki/export/note_sorter.py
@@ -1,4 +1,5 @@
 from ..config.config_settings import ConfigSettings, NoteSortingMethods
+from ..representation.deck import Deck
 
 
 class NoteSorter:
@@ -32,6 +33,13 @@ class NoteSorter:
             notes = list(reversed(notes))
 
         return notes
+
+    def sort_deck(self, deck: Deck):
+        """Sort deck and its subdecks recursively."""
+        deck.notes = self.sort_notes(deck.notes)
+
+        for child_deck in deck.children:
+            self.sort_deck(child_deck)
 
     def get_sort_key(self, note):   
         return tuple(


### PR DESCRIPTION
Fix #188.

The sorting method is the same for all subdecks (but we don't have any means of varying sorting method by deck, anyway, so we're not losing any flexibility).

(I haven't added tests yet.)

On the side:

Add docstring to get_card_ids since its recursiveness had stumped me while inspecting the code. (though we don't actually use children=True anywhere atm.)