### PR TITLE
Fix github workflow

### DIFF
--- a/.github/workflows/mamba.yml
+++ b/.github/workflows/mamba.yml
@@ -48,11 +48,11 @@ jobs:
     - name: Write dulwich version to requirements.txt
       shell: bash
       run: |
-        pipenv requirements | sed -nE 's/(^dulwich==.+$)/\1 --global-option=--pure/p' > requirements.txt
+        pipenv requirements | sed -nE 's/(^dulwich==.+$)/\1 --config-settings "--global-option=--pure"/p' > requirements.txt
 
     - name: Install pure dulwich from requirements.txt
       run: |
-        pipenv run pip install -r requirements.txt
+        pipenv run pip install --no-binary dulwich -r requirements.txt
 
     - name: Install all other dependencies
       shell: bash

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -47,26 +47,65 @@
         },
         "dulwich": {
             "hashes": [
-                "sha256:08a09353620981c8e9cc7ace76f71c8859bf035ae91c1b2bddb54494fe3b7638",
-                "sha256:3ab53d08bc8405cc99a1018e837b2866e0e1d0797999ab94bdfdc3b5369ec325",
-                "sha256:3d4249dd7bd608932ff3e8362b18f9b8ad899436063f8dd395355fd345da92c3",
-                "sha256:555c88a1076cd1cab12c5dac93239e63e2dc4347ae475c5ca0ea5494098eab0f",
-                "sha256:5ff59d02a4d61ee273708b85a8b370d46ea4bedd097904ab92682a2d44553284",
-                "sha256:68cbdeae2e0c247690243c77c8b5cc671d6a091d6fbfcd43ff5eae13210e384f",
-                "sha256:6b61ac0a2a8b1b1e18914310f3f7a422396334208b426b9de570f1de31644cf1",
-                "sha256:7bee1516e0516ff441a93206d0bc0816781ee7f6df37c9f01a9578e2bff7cc7c",
-                "sha256:8025f7249f9ed719af5cf041ac9a8de8fae0bf08875e9dcaedbccc98f4ea67a7",
-                "sha256:8853b0306406f6fb82812d2fc2af43d4cda50ea0223551c3b27df5eb008b655f",
-                "sha256:aba891770d741613a13fc2d76972d99fff9b26a15383ad0f0bfbd3890e2b7a00",
-                "sha256:b9266eba455b399cbda79eac0a138dd80fd8af180e5dcf759d242749936eaeb3",
-                "sha256:bab10f9580372267c3385e3ab9b3939e212a713f398c410d6f1392f96d6f0ffa",
-                "sha256:bcd9c85ea319f7c7076de2717da0532dc99b1e4fd0bea374522af7436179f72f",
-                "sha256:df138aa678e3c6d9c1b21fa8e591311c0871b72fca635cc3c35361a540cc3ad1",
-                "sha256:fc97a857b274f5ed41f73c4593e665924a38f613835cfd72c55393a710a64a49",
-                "sha256:fe649f2c95c209452639075d0ccd8cad6bda960044cf9b2e6268e1ac6ed30bac"
+                "sha256:0aa44b812d978fc22a04531f5090c3c369d5facd03fa6e0501d460a661800c7f",
+                "sha256:0ab86d6d42e385bf3438e70f3c9b16de68018bd88929379e3484c0ef7990bd3c",
+                "sha256:1b20a3656b48c941d49c536824e1e5278a695560e8de1a83b53a630143c4552e",
+                "sha256:1cc0c9ba19ac1b2372598802bc9201a9c45e5d6f1f7a80ec40deeb10acc4e9ae",
+                "sha256:1e39b7c2c9bda6acae83b25054650a8bb7e373e886e2334721d384e1479bf04b",
+                "sha256:26456dba39d1209fca17187db06967130e27eeecad2b3c2bbbe63467b0bf09d6",
+                "sha256:281310644e02e3aa6d76bcaffe2063b9031213c4916b5f1a6e68c25bdecfaba4",
+                "sha256:2aba0fdad2a19bd5bb3aad6882580cb33359c67b48412ccd4cfccd932012b35e",
+                "sha256:32493a456358a3a6c15bbda07106fc3d4cc50834ee18bc7717968d18be59b223",
+                "sha256:3800cdc17d144c1f7e114972293bd6c46688f5bcc2c9228ed0537ded72394082",
+                "sha256:3932b5e17503b265a85f1eda77ede647681c3bab53bc9572955b6b282abd26ea",
+                "sha256:3e68b162af2aae995355e7920f89d50d72b53d56021e5ac0a546d493b17cbf7e",
+                "sha256:3e8f6d4f4f4d01dd1d3c968e486d4cd77f96f772da7265941bc506de0944ddb9",
+                "sha256:45d6198e804b539708b73a003419e48fb42ff2c3c6dd93f63f3b134dff6dd259",
+                "sha256:4814ca3209dabe0fe7719e9545fbdad7f8bb250c5a225964fe2a31069940c4cf",
+                "sha256:494024f74c2eef9988adb4352b3651ac1b6c0466176ec62b69d3d3672167ba68",
+                "sha256:4db330fb59fe3b9d253bdf0e49a521739db83689520c4921ab1c5242aaf77b82",
+                "sha256:5e56b2c1911c344527edb2bf1a4356e2fb7e086b1ba309666e1e5c2224cdca8a",
+                "sha256:5e8a79c1ed7166f32ad21974fa98d11bf6fd74e94a47e754c777c320e01257c6",
+                "sha256:6155ab7388ee01c670f7c5d8003d4e133eebebc7085a856c007989f0ba921b36",
+                "sha256:61e10242b5a7a82faa8996b2c76239cfb633620b02cdd2946e8af6e7eb31d651",
+                "sha256:6616132d219234580de88ceb85dd51480dc43b1bdc05887214b8dd9cfd4a9d40",
+                "sha256:684c52cff867d10c75a7238151ca307582b3d251bbcd6db9e9cffbc998ef804e",
+                "sha256:6f46bcb6777e5f9f4af24a2bd029e88b77316269d24ce66be590e546a0d8f7b7",
+                "sha256:70955e4e249ddda6e34a4636b90f74e931e558f993b17c52570fa6144b993103",
+                "sha256:7dc358c2ee727322a09b7c6da43d47a1026049dbd3ad8d612eddca1f9074b298",
+                "sha256:7f357639b56146a396f48e5e0bc9bbaca3d6d51c8340bd825299272b588fff5f",
+                "sha256:7fe62685bf356bfb4d0738f84a3fcf0d1fc9e11fee152e488a20b8c66a52429e",
+                "sha256:823091d6b6a1ea07dc4839c9752198fb39193213d103ac189c7669736be2eaff",
+                "sha256:82cdf482f8f51fcc965ffad66180b54a9abaea9b1e985a32e1acbfedf6e0e363",
+                "sha256:82f632afb9c7c341a875d46aaa3e6c5e586c7a64ce36c9544fa400f7e4f29754",
+                "sha256:85d3401d08b1ec78c7d58ae987c4bb7b768a438f3daa74aeb8372bebc7fb16fa",
+                "sha256:8864719bc176cdd27847332a2059127e2f7bab7db2ff99a999873cb7fff54116",
+                "sha256:891d5c73e2b66d05dbb502e44f027dc0dbbd8f6198bc90dae348152e69d0befc",
+                "sha256:9019189d7a8f7394df6a22cd5b484238c5776e42282ad5d6d6c626b4c5f43597",
+                "sha256:90479608e49db93d8c9e4323bc0ec5496678b535446e29d8fd67dc5bbb5d51bf",
+                "sha256:a605e10d72f90a39ea2e634fbfd80f866fc4df29a02ea6db52ae92e5fd4a2003",
+                "sha256:a917fd3b4493db3716da2260f16f6b18f68d46fbe491d851d154fc0c2d984ae4",
+                "sha256:aae448da7d80306dda4fc46292fed7efaa466294571ab3448be16714305076f1",
+                "sha256:aeb736d777ee21f2117a90fc453ee181aa7eedb9e255b5ef07c51733f3fe5cb6",
+                "sha256:b24cb1fad0525dba4872e9381bc576ea2a6dcdf06b0ed98f8e953e3b1d719b89",
+                "sha256:b2c9931b657f2206abec0964ec2355ee2c1e04d05f8864e823ffa23c548c4548",
+                "sha256:b943517e30bd651fbc275a892bb96774f3893d95fe5a4dedd84496a98eaaa8ab",
+                "sha256:baecef0d8b9199822c7912876a03a1af17833f6c0d461efb62decebd45897e49",
+                "sha256:be12a46f73023970125808a4a78f610c055373096c1ecea3280edee41613eba8",
+                "sha256:c2a565d4e704d7f784cdf9637097141f6d47129c8fffc2fac699d57cb075a169",
+                "sha256:c8ded43dc0bd2e65420eb01e778034be5ca7f72e397a839167eda7dcb87c4248",
+                "sha256:c922a4573267486be0ef85216f2da103fb38075b8465dc0e90457843884e4860",
+                "sha256:daa607370722c3dce99a0022397c141caefb5ed32032a4f72506f4817ea6405b",
+                "sha256:e2f676bfed8146966fe934ee734969d7d81548fbd250a8308582973670a9dab1",
+                "sha256:e52b20c4368171b7d32bd3ab0f1d2402e76ad4f2ea915ff9aa73bc9fa2b54d6d",
+                "sha256:eaf6c7fb6b13495c19c9aace88821c2ade3c8c55b4e216cd7cc55d3e3807d7fa",
+                "sha256:f2eeca6d61366cf5ee8aef45bed4245a67d4c0f0d731dc2383eabb80fa695683",
+                "sha256:f9a6bf99f57bcac4c77fc60a58f1b322c91cc4d8c65dc341f76bf402622f89cb",
+                "sha256:f9b6ac1b1c67fc6083c42b7b6cd3b211292c8a6517216c733caf23e8b103ab6d",
+                "sha256:fd4ad079758514375f11469e081723ba8831ce4eaa1a64b41f06a3a866d5ac34"
             ],
             "index": "pypi",
-            "version": "==0.20.24"
+            "version": "==0.21.5"
         },
         "future": {
             "hashes": [
@@ -139,6 +178,14 @@
             ],
             "index": "pypi",
             "version": "==3.7.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.5.0"
         },
         "urllib3": {
             "hashes": [
@@ -703,12 +750,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.0.0"
+            "version": "==4.5.0"
         },
         "urllib3": {
             "hashes": [


### PR DESCRIPTION
See: dulwich issue 1093.

Note that with our current version of dulwich (0.20.24) this seems to build dulwich with C bindings.  For testing this is suboptimal but not critical (it's unlikely that dulwich's behaviour differs depending on whether the C bindings are used or not).  (It will be critical for building crowd_anki, though.)

Hence, I've upgraded dulwich.

Fetch dependencies script will also need updating.