### PR TITLE
Allow testing building crowd_anki/dist when Pipfile.lock is changed

### DIFF
--- a/.github/workflows/fetch_dependencies.yml
+++ b/.github/workflows/fetch_dependencies.yml
@@ -1,0 +1,38 @@
+name: Fetch dependencies into dist
+
+on:
+  pull_request:
+    paths: [Pipfile, Pipfile.lock]
+  push:
+    branches: [master]
+    paths: [Pipfile, Pipfile.lock]
+
+jobs:
+  fetch_dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Upgrade pipenv
+      run: |
+        python3 -m pip install --upgrade pipenv
+
+    - name: Check that Pipfile.lock is not stale
+      run: |
+        pipenv verify
+
+    - name: Run fetch_dependencies.sh
+      run: |
+        ./fetch_dependencies.sh
+
+    - name: Upload crowd_anki dist artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: crowd-anki-dist-artifact
+        path: crowd_anki/dist/

--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 
 pipenv run pip install --upgrade --no-binary :all: -r <(pipenv requirements | sed -E "s/(^dulwich==.+$)/\1 --global-option=--pure/")  --target crowd_anki/dist
+
+# Check for Linux shared object files.  This won't work on Windows and might not work on MacOS.
+if [ ! "$(find crowd_anki/dist/ -name '*.so')" == "" ]
+then
+    echo "Found compiled .so file.  Build is not pure python!"
+    exit 1
+fi


### PR DESCRIPTION
The uploaded artifact is currently unused.

Fix #182.

We check for changes to both Pipfile and Pipfile.lock to avoid stale a Pipfile.lock.

This will result in some false positive runs of this workflow, when we've, say, added a new script to Pipfile, without changing dependencies.

We will also have false positives when only dev dependencies have been updated.