### PR TITLE
Fix issue with mutuable default value in dataclass parameter

### DIFF
--- a/crowd_anki/anki/hook_vendor.py
+++ b/crowd_anki/anki/hook_vendor.py
@@ -1,6 +1,6 @@
 from aqt import gui_hooks
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from ..config.config_settings import ConfigSettings
@@ -14,7 +14,7 @@ from ..utils.deckconf import disambiguate_crowdanki_uuid
 class HookVendor:
     window: Any
     config: ConfigSettings
-    hook_manager: AnkiHookManager = AnkiHookManager()
+    hook_manager: AnkiHookManager = field(default_factory=AnkiHookManager)
 
     def setup_hooks(self):
         self.setup_exporter_hook()


### PR DESCRIPTION
Use default_factory to initialize AnkiHookManager instead, solving the ValueError exception enforced since Python 3.11.

See https://docs.python.org/3/library/dataclasses.html#mutable-default-values.

I got the following error upon opening Anki prior to this commit:

```python
When loading '⁨CrowdAnki JSON exportimport Edit history Collaborate on deck creation⁩':
⁨Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/aqt/addons.py", line 246, in loadAddons
    __import__(addon.dir_name)
  File "/home/fredmb/.local/share/Anki2/addons21/1788670778/__init__.py", line 5, in <module>
    from . import main
  File "/home/fredmb/.local/share/Anki2/addons21/1788670778/main.py", line 8, in <module>
    from .anki.hook_vendor import HookVendor
  File "/home/fredmb/.local/share/Anki2/addons21/1788670778/anki/hook_vendor.py", line 13, in <module>
    @dataclass
     ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1223, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1213, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class '1788670778.anki.adapters.hook_manager.AnkiHookManager'> for field hook_manager is not allowed: use default_factory
```
⁩