### PR TITLE
Replace Qt5 attributes with Qt6 ones

### DIFF
--- a/crowd_anki/anki/overrides/change_model_dialog.py
+++ b/crowd_anki/anki/overrides/change_model_dialog.py
@@ -23,7 +23,7 @@ class ChangeModelDialog(QDialog):
         # todo consider extracting UI file
         self.form = aqt.forms.changemodel.Ui_Dialog()
         self.form.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowModality(Qt.WindowModality.WindowModal)
         self.setup()
 
         self.pauseUpdate = False

--- a/crowd_anki/importer/anki_importer.py
+++ b/crowd_anki/importer/anki_importer.py
@@ -89,13 +89,8 @@ class AnkiJsonImporter:
                 import_dict = yaml.full_load(meta_file)
 
         import_dialog = ImportDialog(deck_json, import_dict)
-        # Qt5/Qt6 compat
-        try:
-            if import_dialog.exec() == QDialog.DialogCode.Rejected:
-                return None
-        except AttributeError:
-            if import_dialog.exec_() == QDialog.Rejected:
-                return None
+        if import_dialog.exec() == QDialog.DialogCode.Rejected:
+            return None
 
         return import_dialog.final_import_config
 

--- a/crowd_anki/importer/anki_importer.py
+++ b/crowd_anki/importer/anki_importer.py
@@ -89,8 +89,13 @@ class AnkiJsonImporter:
                 import_dict = yaml.full_load(meta_file)
 
         import_dialog = ImportDialog(deck_json, import_dict)
-        if import_dialog.exec_() == QDialog.Rejected:
-            return None
+        # Qt5/Qt6 compat
+        try:
+            if import_dialog.exec() == QDialog.DialogCode.Rejected:
+                return None
+        except AttributeError:
+            if import_dialog.exec_() == QDialog.Rejected:
+                return None
 
         return import_dialog.final_import_config
 

--- a/crowd_anki/importer/import_dialog.py
+++ b/crowd_anki/importer/import_dialog.py
@@ -95,24 +95,15 @@ class ImportDialog(QDialog):
 
         def add_header(name):
             heading_ui = QListWidgetItem(name)
-            # Qt5/Qt6 compat
-            try:
-                heading_ui.setFlags(Qt.ItemFlag.ItemIsEnabled)
-            except AttributeError:
-                heading_ui.setFlags(Qt.ItemIsEnabled)
+            heading_ui.setFlags(Qt.ItemFlag.ItemIsEnabled)
             heading_ui.setSizeHint(QSize(self.form.list_personal_fields.width(), 30))
             heading_ui.setFont(heading_font)
             self.form.list_personal_fields.addItem(heading_ui)
 
         def add_field(name, is_personal) -> QListWidgetItem:
             field_ui = QListWidgetItem(name)
-            # Qt5/Qt6 compat
-            try:
-                field_ui.setCheckState(Qt.CheckState.Checked if is_personal else Qt.CheckState.Unchecked)
-                field_ui.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
-            except AttributeError:
-                field_ui.setCheckState(Qt.Checked if is_personal else Qt.Unchecked)
-                field_ui.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
+            field_ui.setCheckState(Qt.CheckState.Checked if is_personal else Qt.CheckState.Unchecked)
+            field_ui.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
             self.form.list_personal_fields.addItem(field_ui)
             return field_ui
 
@@ -130,11 +121,7 @@ class ImportDialog(QDialog):
         self.form.import_message_textbox.setText(self.import_defaults.import_message)
 
         if self.import_defaults.suggest_tag_imported_cards:
-            # Qt5/Qt6 compat
-            try:
-                self.form.cb_tag_cards.setCheckState(Qt.CheckState.Checked)
-            except AttributeError:
-                self.form.cb_tag_cards.setCheckState(Qt.Checked)
+            self.form.cb_tag_cards.setCheckState(Qt.CheckState.Checked)
             self.form.cb_tag_cards.setText("Tag Cards (Suggested by Deck Maintainer!)")
         # else:
         # set as default from config settings
@@ -144,11 +131,7 @@ class ImportDialog(QDialog):
 
     def setup_deck_part_checkboxes(self):
         def set_checked_and_text(checkbox, text, count, checked: bool = True):
-            # Qt5/Qt6 compat
-            try:
-                checkbox.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
-            except AttributeError:
-                checkbox.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+            checkbox.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
             if count is not None:
                 text = f"{text}: {'{:,}'.format(count)}"
             checkbox.setText(text)
@@ -176,10 +159,5 @@ class ImportDialog(QDialog):
     def read_personal_fields(self, config):
         for model_name, fields_dict in self.personal_field_ui_dict.items():
             for field_name, widget_item in fields_dict.items():
-                # Qt5/Qt6 compat
-                try:
-                    if widget_item.checkState() == Qt.CheckState.Checked:
-                        config.add_field(model_name, field_name)
-                except AttributeError:
-                    if widget_item.checkState() == Qt.Checked:
-                        config.add_field(model_name, field_name)
+                if widget_item.checkState() == Qt.CheckState.Checked:
+                    config.add_field(model_name, field_name)

--- a/crowd_anki/importer/import_dialog.py
+++ b/crowd_anki/importer/import_dialog.py
@@ -95,15 +95,24 @@ class ImportDialog(QDialog):
 
         def add_header(name):
             heading_ui = QListWidgetItem(name)
-            heading_ui.setFlags(Qt.ItemIsEnabled)
+            # Qt5/Qt6 compat
+            try:
+                heading_ui.setFlags(Qt.ItemFlag.ItemIsEnabled)
+            except AttributeError:
+                heading_ui.setFlags(Qt.ItemIsEnabled)
             heading_ui.setSizeHint(QSize(self.form.list_personal_fields.width(), 30))
             heading_ui.setFont(heading_font)
             self.form.list_personal_fields.addItem(heading_ui)
 
         def add_field(name, is_personal) -> QListWidgetItem:
             field_ui = QListWidgetItem(name)
-            field_ui.setCheckState(Qt.Checked if is_personal else Qt.Unchecked)
-            field_ui.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
+            # Qt5/Qt6 compat
+            try:
+                field_ui.setCheckState(Qt.CheckState.Checked if is_personal else Qt.CheckState.Unchecked)
+                field_ui.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
+            except AttributeError:
+                field_ui.setCheckState(Qt.Checked if is_personal else Qt.Unchecked)
+                field_ui.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
             self.form.list_personal_fields.addItem(field_ui)
             return field_ui
 
@@ -121,7 +130,11 @@ class ImportDialog(QDialog):
         self.form.import_message_textbox.setText(self.import_defaults.import_message)
 
         if self.import_defaults.suggest_tag_imported_cards:
-            self.form.cb_tag_cards.setCheckState(Qt.Checked)
+            # Qt5/Qt6 compat
+            try:
+                self.form.cb_tag_cards.setCheckState(Qt.CheckState.Checked)
+            except AttributeError:
+                self.form.cb_tag_cards.setCheckState(Qt.Checked)
             self.form.cb_tag_cards.setText("Tag Cards (Suggested by Deck Maintainer!)")
         # else:
         # set as default from config settings
@@ -131,7 +144,11 @@ class ImportDialog(QDialog):
 
     def setup_deck_part_checkboxes(self):
         def set_checked_and_text(checkbox, text, count, checked: bool = True):
-            checkbox.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+            # Qt5/Qt6 compat
+            try:
+                checkbox.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
+            except AttributeError:
+                checkbox.setCheckState(Qt.Checked if checked else Qt.Unchecked)
             if count is not None:
                 text = f"{text}: {'{:,}'.format(count)}"
             checkbox.setText(text)
@@ -159,5 +176,10 @@ class ImportDialog(QDialog):
     def read_personal_fields(self, config):
         for model_name, fields_dict in self.personal_field_ui_dict.items():
             for field_name, widget_item in fields_dict.items():
-                if widget_item.checkState() == Qt.Checked:
-                    config.add_field(model_name, field_name)
+                # Qt5/Qt6 compat
+                try:
+                    if widget_item.checkState() == Qt.CheckState.Checked:
+                        config.add_field(model_name, field_name)
+                except AttributeError:
+                    if widget_item.checkState() == Qt.Checked:
+                        config.add_field(model_name, field_name)

--- a/crowd_anki/main.py
+++ b/crowd_anki/main.py
@@ -15,7 +15,7 @@ def invoke_config_window():
     """
     Launch custom GUI on config change instead of default Anki JSON editor
     """
-    mw.crowd_anki_config.exec_()
+    mw.crowd_anki_config.exec()
 
 
 def initialize_config_window(config: ConfigSettings):

--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -88,7 +88,7 @@ class Note(JsonSerializableAnkiObject):
                     NoteModel.ModelMap(dialog.get_field_map(), dialog.get_template_map())
 
             dialog.accepted.connect(on_accepted)
-            dialog.exec_()
+            dialog.exec()
             # todo process cancel
 
         # To get an updated note to work with

--- a/crowd_anki/representation/note_model.py
+++ b/crowd_anki/representation/note_model.py
@@ -71,4 +71,4 @@ class NoteModel(JsonSerializableAnkiDict):
 
         # todo signals instead of direct dialog creation?
 
-        ChangeModelDialog(collection, collection.models.nids(old_model), old_model).exec_()
+        ChangeModelDialog(collection, collection.models.nids(old_model), old_model).exec()


### PR DESCRIPTION
This allows CrowdAnki on Anki 23.10rc1 to run without ENABLE_QT5_COMPAT=1.

I believe that compatibility with Qt5 and Anki 2.1.50->2.1.66 is preserved.

The Qt6 version of the code is in the try clause, while the Qt5 one is in the except.  Hopefully, this will make clean up (once Qt5 is dropped by Anki) simple.

There are still some Qt-unrelated deprecation warnings (but no errors) with 23.10rc1, but it's probably cleanest to deal with them separately, since I'm not sure how easy it will be to make the relevant changes backwards-compatible.