### PR TITLE
Fix hopefully final occurrence of Qt6-incompatibility

### DIFF
--- a/crowd_anki/importer/import_dialog.py
+++ b/crowd_anki/importer/import_dialog.py
@@ -127,7 +127,7 @@ class ImportDialog(QDialog):
         # set as default from config settings
 
         if self.userConfig.import_notes_ignore_deck_movement:
-            self.form.cb_ignore_move_cards.setCheckState(Qt.Checked)
+            self.form.cb_ignore_move_cards.setCheckState(Qt.CheckState.Checked)
 
     def setup_deck_part_checkboxes(self):
         def set_checked_and_text(checkbox, text, count, checked: bool = True):


### PR DESCRIPTION
Oops! I'm glad that I tested one more time...

This would fire/cause breakage when the user had "do not move existing cards" selected.