### PR TITLE
Force syncing of media after import

### DIFF
--- a/crowd_anki/importer/anki_importer.py
+++ b/crowd_anki/importer/anki_importer.py
@@ -54,6 +54,11 @@ class AnkiJsonImporter:
                 full_filename = os.path.join(unicode_media_directory, filename)
                 if os.path.isfile(full_filename):
                     shutil.copy(full_filename, self.collection.media.dir())
+            # Set media dir mtime to force sync of media.  Otherwise,
+            # if no media files are added or removed, Anki will not
+            # sync media changes.  See the Anki source:
+            # https://github.com/ankitects/anki/blob/b7cb0c0d0081202586fd2d88541db962819736b3/rslib/src/sync/media/database/client/changetracker.rs#L59
+            os.utime(self.collection.media.dir())
         else:
             print("Warning: no media directory exists.")
 


### PR DESCRIPTION
Otherwise, if in the source CrowdAnki decks a file has only been edited, this won't be synced to other devices.

By default, Anki only checks whether it should more expensively check for changes to individual media files if the mtime of the entire media directory has changed.

(According to the docs:

https://docs.ankiweb.net/syncing.html#media

> It will notice when media has been added, removed or replaced in
> your media folder, but will not notice if you have made edits to
> existing files.

However, the mechanism by which it checks for this is via the directory is (currently!) via the mtime of the dir:

https://github.com/ankitects/anki/blob/b7cb0c0d0081202586fd2d88541db962819736b3/rslib/src/sync/media/database/client/changetracker.rs#L94

)

Note that this means that every time CrowdAnki imports a deck, with media, Anki will have to perform the more expensive check.

The cost of this "second" check was deemed sufficiently high that the current behaviour (of two checks) was (re-)introduced here:

https://github.com/ankitects/anki/commit/35cbde65d7c5cf17ce0c75e73648ba348f5a4dc3

However, given that importing CrowdAnki decks is not a frequent occurrence (probably less frequent than adding new media files oneself — which also triggers the "second" check), this is a worthwhile change.

For background see here:

https://github.com/anki-geo/ultimate-geography/issues/638#issuecomment-2322983254