### PR TITLE
Use col.update_note since note.flush is deprecated

### DIFF
--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -127,7 +127,7 @@ class Note(JsonSerializableAnkiObject):
         if new_note:
             collection.add_note(self.anki_object, deck.anki_dict["id"])
         else:
-            self.anki_object.flush()
+            collection.update_note(self.anki_object, skip_undo_entry=True)
             if not import_config.ignore_deck_movement:
                 self.move_cards_to_deck(deck.anki_dict["id"])
 


### PR DESCRIPTION
note.flush is deprecated since 2023-10-17

(b23f17df276e2523a838be4cae5a08ca6fda1d71)

col.update_note has been present for a while longer than that but it's not 100% clear that it was a drop-in replacement for .flush, then.

Hence, to be safe, we'll need to drop compatibility with Anki versions older than those from ~ 2023-10.

Currently, note.flush just calls col._backend.update_notes with skip_undo_entry=True, as does update_note, so they are 100% equivalent
(other than the warning message).

https://github.com/ankitects/anki/blob/ ccab18b7ba624d888f3d881e14f04c830e3eaa44/pylib/anki/notes.py#L88

<hr/>

Our version of Python needs to be updated for the tests to pass...