### PR TITLE
Prevent card flushing if deck_id does not change

### DIFF
--- a/crowd_anki/anki/overrides/cards.py
+++ b/crowd_anki/anki/overrides/cards.py
@@ -8,15 +8,24 @@ def move_to_deck(self, deck_id, move_from_dynamic_deck=False):
     :parameter move_from_dynamic_deck Specifies if we should perform move if card is in dynamic deck
      or should we just change it's "odid" old/original deck id.
      The function is not doing flush, so you need to call flush yourself in order to persist changes into DB
+    :return: True if card was changed, False otherwise.
     """
+    changed = False
     if move_from_dynamic_deck:
         self.col.sched.remFromDyn([self.id])
         self.load()
+        changed = True
 
     if self.odid:
-        self.odid = deck_id
+        if self.odid != deck_id:
+            self.odid = deck_id
+            changed = True
     else:
-        self.did = deck_id
+        if self.did != deck_id:
+            self.did = deck_id
+            changed = True
+
+    return changed
 
 
 Card.move_to_deck = move_to_deck

--- a/crowd_anki/representation/note.py
+++ b/crowd_anki/representation/note.py
@@ -4,7 +4,6 @@ from anki.notes import Note as AnkiNote
 from .json_serializable import JsonSerializableAnkiObject
 from .note_model import NoteModel
 from ..anki.overrides.change_model_dialog import ChangeModelDialog
-from ..importer.import_dialog import ImportConfig
 from ..config.config_settings import ConfigSettings
 from ..utils.constants import UUID_FIELD_NAME
 from ..utils.uuid import UuidFetcher
@@ -94,7 +93,7 @@ class Note(JsonSerializableAnkiObject):
         # To get an updated note to work with
         self.anki_object = uuid_fetcher.get_note(self.get_uuid())
 
-    def move_cards_to_deck(self, deck_id, move_from_dynamic_decks=False):
+    def move_cards_to_deck(self, collection, deck_id, move_from_dynamic_decks=False):
         """
         Move all cards for note with given id to specified deck.
         :param deck_id:
@@ -103,8 +102,9 @@ class Note(JsonSerializableAnkiObject):
         """
         # Todo: consider move only when majority of cards are in a different deck.
         for card in self.anki_object.cards():
-            card.move_to_deck(deck_id, move_from_dynamic_decks)
-            card.flush()
+            changed = card.move_to_deck(deck_id, move_from_dynamic_decks)
+            if changed: 
+                collection.update_card(card)
 
     def save_to_collection(self, collection, deck, model_map_cache, import_config):
         # Todo uuid match on existing notes
@@ -129,7 +129,7 @@ class Note(JsonSerializableAnkiObject):
         else:
             collection.update_note(self.anki_object, skip_undo_entry=True)
             if not import_config.ignore_deck_movement:
-                self.move_cards_to_deck(deck.anki_dict["id"])
+                self.move_cards_to_deck(collection, deck.anki_dict["id"])
 
     def handle_import_config_changes(self, import_config, note_model):
         # Personal Fields


### PR DESCRIPTION
Fixes #228 by preventing unconditional updates to the collection if the `card.deck_id` does not change on json import.

The default behavior would call `card.flush()` no matter if the card would move or not. I added a boolean output to the  `Card.move_to_deck()` override so that we could detect if there were changes and avoid this behavior.

I also changed the call of `card.flush()` to `collection.update_card()`, as `card.flush()` is marked as deprecated in the current anki library. I checked the implementation, and it seems that `card.flush()` and `collection.update_card()` are functionally identical, so no worries there. 

I tested manually on my local Anki, confirming that card moving behavior is identical to before, and also confirmed that if no cards move, there is no full sync. Given the minimal nature of this change, I feel confident saying that behavior is otherwise identical. Let me know if you would like further testing.