### PR TITLE
Fix Git import for nested export folders

### DIFF
--- a/crowd_anki/importer/anki_importer.py
+++ b/crowd_anki/importer/anki_importer.py
@@ -65,15 +65,22 @@ class AnkiJsonImporter:
     def get_deck_path(self, directory_path):
         """
         Provides compatibility layer between deck file naming conventions.
-        Assumes that deck json file is located in the directory and named 'deck.json'
+        Prefers a direct 'deck.json', then a unique 'deck.json' found anywhere
+        below the selected directory.
         """
 
         def path_for_name(name):
             return directory_path.joinpath(name).with_suffix(DECK_FILE_EXTENSION)
 
         convention_path = path_for_name(self.deck_file_name)   # [folder]/deck.json
-        inferred_path = path_for_name(directory_path.name)     # [folder]/[folder].json
-        return convention_path if convention_path.exists() else inferred_path
+        if convention_path.exists():
+            return convention_path
+
+        deck_json_files = list(directory_path.rglob(f"{self.deck_file_name}{DECK_FILE_EXTENSION}"))
+        if len(deck_json_files) == 1:
+            return deck_json_files[0]
+
+        return convention_path
 
     @staticmethod
     def read_deck(file_path: Path):


### PR DESCRIPTION
Hi, first of all, thanks for this great addon. It helps a lot!

I ran into a small problem:

I had an Anki deck named `cryllic` for learning the Cyrillic alphabet and tried using it with CrowdAnki. I exported it, but I chose to export it into a custom folder named `anki-cryllic`, since that seemed more suitable for GitHub usage with a clearer name.

The exporter created an additional nested folder named `cryllic` inside the `anki-cryllic` directory. I then pushed this structure to GitHub in this repository:

https://github.com/cnra/anki-cryllic

Then I tried to import it from GitHub. However, the import failed because `deck.json` was not found. The file was not at the root of the repository checkout, but inside the nested folder.

I inspected the code and saw that nested directories were already considered, but only under the assumption that the nested folder name is the same as the root folder name. In this example, it was not.

This fix makes the import logic more general: it now finds `deck.json` wherever it exists inside the nested export directory.
