### PR TITLE
Regenerate hash for newer versions of pipenv

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b72f48138ed5efb76170561f0f80c6dbe138fe8669b50fd76dcff3bffe5c5502"
+            "sha256": "5e63b4dc808d780215e833c0f60f22884ea446228aec06d26186b85a53c05413"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
(I have no idea why old/new versions of pipenv generate a different hash...)

This should allow pipenv verify to "pass" and unbork our CI.

(Separately, we should bump our dependencies, especially dulwich, but I think it's better as a separate PR, since dulwich's internals changed.)