### PR TITLE
Run apt-get update in mamba test (in gh actions)

### DIFF
--- a/.github/workflows/mamba.yml
+++ b/.github/workflows/mamba.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install OpenGL for Qt6 dev dependency
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get install freeglut3-dev
+        sudo apt-get update && sudo apt-get install freeglut3-dev
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v2


### PR DESCRIPTION
Otherwise, in the relatively rare case when Ubuntu has pushed security updates to a package (and hence AFAIU the old packages have been removed from the security pool) we will get a 404 Not Found error when trying to install freeglut3-dev.

This will slow down all runs of ou mamba action by several seconds (~ 6 s) but we'll avoid the rare but very annoying flaky failure.  (Ideally we'd cache everything up to and including the pip installs, but that's probably overkill for our sporadic CI.)